### PR TITLE
feat: custom domain names for apis

### DIFF
--- a/lib/ingestor-api/index.ts
+++ b/lib/ingestor-api/index.ts
@@ -191,6 +191,7 @@ export class StacIngestor extends Construct {
     stage: string;
     policy?: iam.PolicyDocument;
     endpointConfiguration?: apigateway.EndpointConfiguration;
+    ingestorDomainNameOptions?: apigateway.DomainNameOptions;
   }): apigateway.LambdaRestApi {
     return new apigateway.LambdaRestApi(
       this,
@@ -205,6 +206,11 @@ export class StacIngestor extends Construct {
 
         endpointConfiguration: props.endpointConfiguration,
         policy: props.policy,
+
+        domainName:  props.ingestorDomainNameOptions ? {
+          domainName: props.ingestorDomainNameOptions.domainName,
+          certificate: props.ingestorDomainNameOptions.certificate,
+        } : undefined,
       }
     );
   }
@@ -277,4 +283,9 @@ export interface StacIngestorProps {
    * API Policy Document, useful for creating private APIs.
    */
   readonly apiPolicy?: iam.PolicyDocument;
+
+  /**
+   * Custom Domain Name Options for Ingestor API
+   */
+   readonly ingestorDomainNameOptions?: apigateway.DomainNameOptions;
 }

--- a/lib/ingestor-api/index.ts
+++ b/lib/ingestor-api/index.ts
@@ -62,6 +62,7 @@ export class StacIngestor extends Construct {
       stage: props.stage,
       endpointConfiguration: props.apiEndpointConfiguration,
       policy: props.apiPolicy,
+      ingestorDomainNameOptions: props.ingestorDomainNameOptions,
     });
 
     this.buildIngestor({
@@ -193,6 +194,7 @@ export class StacIngestor extends Construct {
     endpointConfiguration?: apigateway.EndpointConfiguration;
     ingestorDomainNameOptions?: apigateway.DomainNameOptions;
   }): apigateway.LambdaRestApi {
+
     return new apigateway.LambdaRestApi(
       this,
       `${Stack.of(this).stackName}-ingestor-api`,

--- a/lib/stac-api/index.ts
+++ b/lib/stac-api/index.ts
@@ -10,7 +10,7 @@ import {
   PythonFunction,
   PythonFunctionProps,
 } from "@aws-cdk/aws-lambda-python-alpha";
-import { HttpApi } from "@aws-cdk/aws-apigatewayv2-alpha";
+import { IDomainName, HttpApi } from "@aws-cdk/aws-apigatewayv2-alpha";
 import { HttpLambdaIntegration } from "@aws-cdk/aws-apigatewayv2-integrations-alpha";
 import { Construct } from "constructs";
 
@@ -58,6 +58,9 @@ export class PgStacApiLambda extends Construct {
     this.stacApiLambdaFunction.connections.allowTo(props.db, ec2.Port.tcp(5432));
 
     const stacApi = new HttpApi(this, `${Stack.of(this).stackName}-stac-api`, {
+      defaultDomainMapping: props.stacApiDomainName ? { 
+        domainName: props.stacApiDomainName
+      } : undefined,
       defaultIntegration: new HttpLambdaIntegration("integration", this.stacApiLambdaFunction),
     });
 
@@ -102,6 +105,11 @@ export interface PgStacApiLambdaProps {
    * Customized environment variables to send to fastapi-pgstac runtime.
    */
   readonly apiEnv?: Record<string, string>;
+
+  /**
+   * Custom Domain Name Options for STAC API,
+   */
+   readonly stacApiDomainName?: IDomainName;
 }
 
 export interface ApiEntrypoint {

--- a/lib/titiler-pgstac-api/index.ts
+++ b/lib/titiler-pgstac-api/index.ts
@@ -9,7 +9,7 @@ import {
     Duration,
     aws_logs,
   } from "aws-cdk-lib";
-  import { HttpApi } from "@aws-cdk/aws-apigatewayv2-alpha";
+  import { IDomainName, HttpApi } from "@aws-cdk/aws-apigatewayv2-alpha";
   import { HttpLambdaIntegration } from "@aws-cdk/aws-apigatewayv2-integrations-alpha";
   import { Construct } from "constructs";
   
@@ -67,6 +67,9 @@ import {
       this.titilerPgstacLambdaFunction.connections.allowTo(props.db, ec2.Port.tcp(5432), "allow connections from titiler");
   
       const stacApi = new HttpApi(this, `${Stack.of(this).stackName}-titiler-pgstac-api`, {
+        defaultDomainMapping: props.titilerPgstacApiDomainName ? { 
+          domainName: props.titilerPgstacApiDomainName 
+        } : undefined,
         defaultIntegration: new HttpLambdaIntegration("integration", this.titilerPgstacLambdaFunction),
       });
   
@@ -111,4 +114,8 @@ import {
      */
     readonly buckets?: string[];
 
+    /**
+     * Custom Domain Name Options for Titiler Pgstac API,
+     */
+    readonly titilerPgstacApiDomainName?: IDomainName;
   }

--- a/lib/titiler-pgstac-api/runtime/src/handler.py
+++ b/lib/titiler-pgstac-api/runtime/src/handler.py
@@ -20,10 +20,8 @@ os.environ.update(
     }
 )
 
-from titiler.pgstac.main import app
-from titiler.pgstac.db import connect_to_db
-
-
+from titiler.pgstac.main import app  # noqa: E402
+from titiler.pgstac.db import connect_to_db  # noqa: E402
 
 
 @app.on_event("startup")

--- a/lib/titiler-pgstac-api/runtime/src/handler.py
+++ b/lib/titiler-pgstac-api/runtime/src/handler.py
@@ -6,8 +6,6 @@ import asyncio
 import os
 from mangum import Mangum
 from utils import get_secret_dict
-from titiler.pgstac.main import app
-from titiler.pgstac.db import connect_to_db
 
 pgstac_secret_arn = os.environ["PGSTAC_SECRET_ARN"]
 
@@ -21,6 +19,11 @@ os.environ.update(
         "postgres_port": str(secret["port"]),
     }
 )
+
+from titiler.pgstac.main import app
+from titiler.pgstac.db import connect_to_db
+
+
 
 
 @app.on_event("startup")


### PR DESCRIPTION
- adds the ability for wrappers to pass custom domain names to apigateway constructs
- fixes a titiler-pgstac application bug introduced in https://github.com/developmentseed/eoapi-cdk/pull/61

example implementation: https://github.com/MAAP-Project/maap-eoapi/pull/15
