### PR TITLE
add params for package versions

### DIFF
--- a/lib/database/index.ts
+++ b/lib/database/index.ts
@@ -68,7 +68,7 @@ export class PgStacDatabase extends Construct {
       timeout: Duration.minutes(2),
       code: aws_lambda.Code.fromDockerBuild(__dirname, {
         file: "bootstrapper_runtime/Dockerfile",
-        buildArgs: {PGSTAC_VERSION: DEFAULT_PGSTAC_VERSION, PYTHON_VERSION: "3.11"}
+        buildArgs: {PGSTAC_VERSION: props.pgstacVersion || DEFAULT_PGSTAC_VERSION, PYTHON_VERSION: "3.11"}
       }),
       // overwrites defaults with user-provided configurable properties
       ...props.bootstrapperLambdaFunctionOptions,
@@ -120,7 +120,7 @@ export class PgStacDatabase extends Construct {
 
     // if props.lambdaFunctionOptions doesn't have 'code' defined, update pgstac_version (needed for default runtime)
     if (!props.bootstrapperLambdaFunctionOptions?.code) {
-      customResourceProperties["pgstac_version"] = DEFAULT_PGSTAC_VERSION;
+      customResourceProperties["pgstac_version"] = props.pgstacVersion || DEFAULT_PGSTAC_VERSION;
     }
     // this.connections = props.database.connections;
     new CustomResource(this, "bootstrapper", {
@@ -192,6 +192,13 @@ export interface PgStacDatabaseProps extends rds.DatabaseInstanceProps {
    * @default pgstac_user
    */
   readonly pgstacUsername?: string;
+
+  /**
+   * Version of pgstac to install on the database
+   * 
+   * @default 0.7.10
+   */
+  readonly pgstacVersion?: string;
 
   /**
    * Lambda function Custom Resource properties. A custom resource property is going to be created

--- a/lib/stac-api/index.ts
+++ b/lib/stac-api/index.ts
@@ -13,6 +13,8 @@ import { HttpLambdaIntegration } from "@aws-cdk/aws-apigatewayv2-integrations-al
 import { Construct } from "constructs";
 import { CustomLambdaFunctionProps } from "../utils";
 
+const DEFAULT_STAC_FASTAPI_VERSION = "2.4.8";
+
 export class PgStacApiLambda extends Construct {
   readonly url: string;
   public stacApiLambdaFunction: lambda.Function;
@@ -31,7 +33,7 @@ export class PgStacApiLambda extends Construct {
       timeout: Duration.seconds(30),
       code: lambda.Code.fromDockerBuild(__dirname, {
         file: "runtime/Dockerfile",
-        buildArgs: { PYTHON_VERSION: '3.11' },
+        buildArgs: { PYTHON_VERSION: '3.11', STAC_FASTAPI_VERSION: props.stacFastapiVersion || DEFAULT_STAC_FASTAPI_VERSION },
       }),
       // overwrites defaults with user-provided configurable properties
       ...props.lambdaFunctionOptions,
@@ -87,6 +89,13 @@ export interface PgStacApiLambdaProps {
    * Secret containing connection information for pgSTAC database.
    */
   readonly dbSecret: secretsmanager.ISecret;
+
+  /**
+   * Version of stac-fastapi to install in the Lambda Docker image 
+   * 
+   * @default 2.4.8
+   */
+  readonly stacFastapiVersion?: string;
 
   /**
    * Customized environment variables to send to fastapi-pgstac runtime.

--- a/lib/stac-api/runtime/Dockerfile
+++ b/lib/stac-api/runtime/Dockerfile
@@ -4,8 +4,15 @@ FROM --platform=linux/amd64 public.ecr.aws/lambda/python:${PYTHON_VERSION}
 WORKDIR /tmp
 RUN python -m pip install pip -U
 
+ARG STAC_FASTAPI_VERSION=2.4.8
 COPY runtime/requirements.txt requirements.txt
-RUN python -m pip install -r requirements.txt "mangum>=0.14,<0.15" -t /asset --no-binary pydantic
+RUN python -m pip install -r requirements.txt \
+  stac-fastapi.api==${STAC_FASTAPI_VERSION} \
+  stac-fastapi.extensions==${STAC_FASTAPI_VERSION} \
+  stac-fastapi.pgstac==${STAC_FASTAPI_VERSION} \
+  stac-fastapi.types==${STAC_FASTAPI_VERSION} \
+  "mangum>=0.14,<0.15" \
+  -t /asset --no-binary pydantic
 
 RUN mkdir -p /asset/src
 COPY runtime/src/*.py /asset/src/

--- a/lib/stac-api/runtime/requirements.txt
+++ b/lib/stac-api/runtime/requirements.txt
@@ -1,7 +1,3 @@
-stac-fastapi.api==2.4.8
-stac-fastapi.extensions==2.4.8
-stac-fastapi.pgstac==2.4.8
-stac-fastapi.types==2.4.8
-# https://github.com/stac-utils/stac-fastapi/pull/466
+# pin pygeoif: https://github.com/stac-utils/stac-fastapi/pull/466
 pygeoif==0.7
 starlette_cramjam

--- a/lib/tipg-api/index.ts
+++ b/lib/tipg-api/index.ts
@@ -13,6 +13,8 @@ import {
   import { Construct } from "constructs";
   import { CustomLambdaFunctionProps } from "../utils";
 
+  const DEFAULT_TIPG_VERSION = "0.3.1";
+
   export class TiPgApiLambda extends Construct {
     readonly url: string;
     public tiPgLambdaFunction: lambda.Function;
@@ -29,7 +31,7 @@ import {
         timeout: Duration.seconds(30),
         code: lambda.Code.fromDockerBuild(__dirname, {
         file: "runtime/Dockerfile",
-        buildArgs: { PYTHON_VERSION: '3.11' },
+          buildArgs: { PYTHON_VERSION: '3.11', TIPG_VERSION: props.tipgVersion || DEFAULT_TIPG_VERSION },
         }),
         // overwrites defaults with user-provided configurable properties
         ...props.lambdaFunctionOptions,
@@ -87,6 +89,12 @@ import {
      */
     readonly dbSecret: secretsmanager.ISecret;
 
+    /**
+     * Version of tipg to install in the Lambda Docker image 
+     * 
+     * @default 0.3.1
+     */
+    readonly tipgVersion?: string;
 
     /**
      * Customized environment variables to send to titiler-pgstac runtime.

--- a/lib/tipg-api/runtime/Dockerfile
+++ b/lib/tipg-api/runtime/Dockerfile
@@ -4,7 +4,8 @@ FROM --platform=linux/amd64 public.ecr.aws/lambda/python:${PYTHON_VERSION}
 WORKDIR /tmp
 RUN python -m pip install pip -U
 
-RUN python -m pip install tipg==0.3.1 "mangum>=0.14,<0.15" -t /asset --no-binary pydantic
+ARG TIPG_VERSION=0.3.1
+RUN python -m pip install tipg==${TIPG_VERSION} "mangum>=0.14,<0.15" -t /asset --no-binary pydantic
 
 # Reduce package size and remove useless files
 RUN cd /asset && find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[0-9]*//'); cp $f $n; done;

--- a/lib/titiler-pgstac-api/index.ts
+++ b/lib/titiler-pgstac-api/index.ts
@@ -14,6 +14,7 @@ import {
   import { Construct } from "constructs";
 import { CustomLambdaFunctionProps } from "../utils";
   
+  const DEFAULT_TITILER_PGSTAC_VERSION = "0.5.1";
 
   // default settings that can be overridden by the user-provided environment. 
   let defaultTitilerPgstacEnv :{ [key: string]: any } = {
@@ -47,7 +48,7 @@ import { CustomLambdaFunctionProps } from "../utils";
         timeout: Duration.seconds(30),
         code: lambda.Code.fromDockerBuild(__dirname, {
           file: "runtime/Dockerfile",
-          buildArgs: { PYTHON_VERSION: '3.11' }
+          buildArgs: { PYTHON_VERSION: '3.11' , TITILER_PGSTAC_VERSION: props.titilerPgstacVersion || DEFAULT_TITILER_PGSTAC_VERSION }
         }),
         // overwrites defaults with user-provided configurable properties
         ...props.lambdaFunctionOptions,
@@ -112,6 +113,13 @@ import { CustomLambdaFunctionProps } from "../utils";
      * Secret containing connection information for pgSTAC database.
      */
     readonly dbSecret: secretsmanager.ISecret;
+
+    /**
+     * Version of titiler-pgstac to install in the Lambda Docker image 
+     * 
+     * @default 0.5.1
+     */
+    readonly titilerPgstacVersion?: string;
 
     /**
      * Customized environment variables to send to titiler-pgstac runtime. These will be merged with `defaultTitilerPgstacEnv`.

--- a/lib/titiler-pgstac-api/runtime/Dockerfile
+++ b/lib/titiler-pgstac-api/runtime/Dockerfile
@@ -4,8 +4,9 @@ FROM --platform=linux/amd64 public.ecr.aws/lambda/python:${PYTHON_VERSION}
 WORKDIR /tmp
 RUN python -m pip install pip -U
 
+ARG TITILER_PGSTAC_VERSION=0.5.1
 COPY runtime/requirements.txt requirements.txt
-RUN python -m pip install -r requirements.txt "mangum>=0.14,<0.15" -t /asset
+RUN python -m pip install -r requirements.txt "mangum>=0.14,<0.15" titiler.pgstac==${TITILER_PGSTAC_VERSION} -t /asset
 
 # Reduce package size and remove useless files
 RUN find /asset -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[0-9]*//'); cp $f $n; done;

--- a/lib/titiler-pgstac-api/runtime/requirements.txt
+++ b/lib/titiler-pgstac-api/runtime/requirements.txt
@@ -1,2 +1,1 @@
-titiler.pgstac==0.5.1
 psycopg[binary, pool]


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- make it possible to configure the versions of these packages without custom runtimes
  - tipg
  - titiler-pgstac
  - stac-fastapi
  - pgstac

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- added a constant to the top of each relevant typescript file with the default version as specified in v6.1.0
- added new arguments to the relevant constructs
  - `TitilerPgstacApiLambda`: `titiler_pgstac_version`
  - `PgStacApiLambda`: `stac_fastapi_version`
  - `PgStacDatabase`: `pgstac_version`
  - `TiPgApiLambda`: `tipg_version`
- used docker build args to specify the versions at build time

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- run an eoapi-template deployment with no versions specified - this should yield an identical deployment to v6.1.0
- run an eoapi-template deployment with user-specified versions of titiler-pgstac, tipg, pgstac, stac-fastapi
  ```python
  # STAC DB
  pgstac_db = PgStacDatabase(
      self,
      "pgstac-db",
      pgstac_version="0.8.2",
      ...
  )

  # titiler-pgstac
  TitilerPgstacApiLambda(
      self,
      "titiler-pgstac-api",
      titiler_pgstac_version="0.7.10",
      ...
  )

  # stac-fastapi
  stac_api_lambda = PgStacApiLambda(
      self,
      "pgstac-api",
      stac_fastapi_version="2.4.9",
      ...
  )

  # tipg
  TiPgApiLambda(
      self,
      "tipg-api",
      tipg_version="0.5.1",
      ...
  )
  ```

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- resolves #85 
