### PR TITLE
chore: make deployment workflow manual and add a reminder in pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,2 @@
+## :warning: Checklist if your PR is changing anything else than documentation
+- [ ] The manual deployment workflow ran successfully

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,8 +1,7 @@
-name: Test deployment
+name: Deployment
 
 on:
-  merge_group:
-    branches: [ main ]
+  workflow_dispatch:
     
 jobs:
   build_package_and_deploy:


### PR DESCRIPTION
In a [previous PR](https://github.com/developmentseed/eoapi-cdk/pull/69), I added a [workflow that was meant to run before any release](https://github.com/developmentseed/eoapi-cdk/issues/13) and which purpose is to use the constructs in a simple real-world deployment that we immediately destroy, before actually doing a release, to do a basic sanity check. 

The system doesn't work. As basic as it may sound, it's actually **_not_** easy to set that up. 

I recap. We have a long and costly job (deployment) that we want to run _only_ if a release is _about_ to happen. I contemplated two options to implement this : 

1. Add two steps before the `Maybe Release` step (that does the release) : `Check if release is going to happen`, which would produce a boolean output variable called `RELEASE_IS_GOING_TO_HAPPEN`, and a subsequent step called `Deploy if release is going to happen`, that runs a deployment if `RELEASE_IS_GOING_TO_HAPPEN` is true. Unfortunately, there is no, afaik, any supported functionality in `semantic-release` to obtain this kind of information. People are grabbing the `stdout` of `semantic-release` and parsing it to know if a release is about to happen, and although it can work, I tried, and : it makes the code complicated, and what if someone bumps `semantic-release` in the future without knowing that it's going to change the `stdout` ? 

2. Use `merge_queues`, which is a github feature that allows one to have merges added to a queue when someone clicks on 'merge' in a PR and then selected checks can happen in the queue. This would work nicely but unfortunately prevents our automated release system from functioning entirely, since the release bot can't push to `main` anymore. Maybe a solution to that is a two-branch system (merge first to `staging` with merge queues and the release bot picks up what's in `staging`) but that adds complexity.


**I shouldn't spend more time on this. So I am going with the sub-optimal third option which is to have a human in the loop : the deployment workflow is to be triggered manually on the console at each PR that contains code changes. I am adding a warning in a pull request template to remind people.**
 