### PR TITLE
fix: install compilation dependency for numexpr

### DIFF
--- a/.github/workflows/conventional-pr.yaml
+++ b/.github/workflows/conventional-pr.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Get Release Bot Token
         id: get-token
-        uses: getsentry/action-github-app-token@v1
+        uses: getsentry/action-github-app-token@v3
         with:
           app_id: ${{ secrets.DS_RELEASE_BOT_ID }}
           private_key: ${{ secrets.DS_RELEASE_BOT_PRIVATE_KEY }}

--- a/lib/titiler-pgstac-api/runtime/Dockerfile
+++ b/lib/titiler-pgstac-api/runtime/Dockerfile
@@ -4,8 +4,14 @@ FROM --platform=linux/amd64 public.ecr.aws/lambda/python:${PYTHON_VERSION}
 WORKDIR /tmp
 RUN python -m pip install pip -U
 
+# Install system dependencies to compile (numexpr)
+RUN yum install -y gcc-c++
+
 COPY runtime/requirements.txt requirements.txt
 RUN python -m pip install -r requirements.txt "mangum>=0.14,<0.15" -t /asset
+
+# Remove system dependencies
+RUN yum remove -y gcc-c++
 
 # Reduce package size and remove useless files
 RUN find /asset -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[0-9]*//'); cp $f $n; done;


### PR DESCRIPTION
## :warning: Checklist if your PR is changing anything else than documentation
- [ ] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction)

## Merge request description
`numexpr>=2.10.1` requires `g++` when installing. See https://github.com/pydata/numexpr/issues/493 for an explanation.

Resolves #107 