### PR TITLE
feat: set search_path to include pgstac for eoapi user

### DIFF
--- a/lib/database/bootstrapper_runtime/handler.py
+++ b/lib/database/bootstrapper_runtime/handler.py
@@ -127,6 +127,7 @@ def update_user_permissions(cursor, db_name: str, username: str) -> None:
             "GRANT pgstac_read TO {username};"
             "GRANT pgstac_ingest TO {username};"
             "GRANT pgstac_admin TO {username};"
+            "ALTER USER {username} SET search_path TO pgstac, public;"  # add pgstac to search_path by default
         ).format(
             db_name=sql.Identifier(db_name),
             username=sql.Identifier(username),


### PR DESCRIPTION
## :warning: Checklist if your PR is changing anything else than documentation
- [x] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction)

## Merge request description
Adding `pgstac` to the `search_path` for the eoapi database user makes it possible to use `pgbouncer` as a connection pooler for applications that connect to the pgstac database. Without setting this for the user it is impossible to use `pgbouncer` because it does not allow a client to specify options like `search_path` or `application_name` with the connection string.

successful deployment action: https://github.com/developmentseed/eoapi-cdk/actions/runs/12189254944/job/34004022350