### PR TITLE
fix: update units for effectiveCacheSize and tempBuffers

### DIFF
--- a/lib/database/index.ts
+++ b/lib/database/index.ts
@@ -159,11 +159,11 @@ export class PgStacDatabase extends Construct {
     return {
       maxConnections: `${maxConnections}`,
       sharedBuffers: `${sharedBuffers / 8}`, // Represented in 8kb blocks
-      effectiveCacheSize: `${effectiveCacheSize}`,
+      effectiveCacheSize: `${effectiveCacheSize / 8}`, // Represented in 8kb blocks
       workMem: `${workMem}`,
       maintenanceWorkMem: `${maintenanceWorkMem}`,
       maxLocksPerTransaction: "1024",
-      tempBuffers: `${tempBuffers}`,
+      tempBuffers: `${tempBuffers / 8}`, // Represented in 8kb blocks
       seqPageCost: `${seqPageCost}`,
       randomPageCost: `${randomPageCost}`,
     };


### PR DESCRIPTION
## :warning: Checklist if your PR is changing anything else than documentation
- [x] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction)

## Merge request description
The `effectiveCacheSize` and `tempBuffers` parameters need to be described in number of 8kb blocks like `sharedBuffers`.
 https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.Parameters.html

Successful deployment workflow run: https://github.com/developmentseed/eoapi-cdk/actions/runs/12241535813