### PR TITLE
fix: install packaging>=24.2 with twine

### DIFF
--- a/.github/workflows/distribute.yaml
+++ b/.github/workflows/distribute.yaml
@@ -19,7 +19,7 @@ jobs:
           name: python
           path: dist
 
-      - run: pip install twine
+      - run: pip install "twine>=6.1.0" "packaging>=24.2"
 
       - run: twine upload dist/*
         env:


### PR DESCRIPTION
There is a bug in `twine` that causes this error: https://github.com/developmentseed/eoapi-cdk/actions/runs/12952156141/job/36130167690

see https://github.com/pypa/twine/issues/1216 for details

## :warning: Checklist if your PR is changing anything else than documentation
- [ ] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction)

## Merge request description
