### PR TITLE
fix: ensure dependency secret update function completes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,9 +18,9 @@ jobs:
     name: Build and package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: "npm"
@@ -37,22 +37,22 @@ jobs:
       - name: Generate documentation
         run: npm run docgen
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: docs
           path: docs
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: python
           path: dist/python/*
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: js
           path: dist/js/*
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: jsii
           path: .jsii

--- a/integration_tests/cdk/app.py
+++ b/integration_tests/cdk/app.py
@@ -85,6 +85,9 @@ class pgStacInfraStack(Stack):
 
         assert pgstac_db.security_group
 
+        # make sure we can get the secret value!
+        assert pgstac_db.pgstac_secret.secret_value_from_json("host").to_string()
+
         pgstac_db.security_group.add_ingress_rule(
             aws_ec2.Peer.any_ipv4(), aws_ec2.Port.tcp(5432)
         )

--- a/lib/database/index.ts
+++ b/lib/database/index.ts
@@ -171,7 +171,9 @@ export class PgStacDatabase extends Construct {
       this._pgBouncerServer.node.addDependency(bootstrapper);
 
       this.pgstacSecret = this._pgBouncerServer.pgbouncerSecret;
+
       this.connectionTarget = this._pgBouncerServer.instance;
+
       this.securityGroup = this._pgBouncerServer.securityGroup;
     } else {
       this.connectionTarget = this.db;

--- a/lib/database/index.ts
+++ b/lib/database/index.ts
@@ -171,9 +171,7 @@ export class PgStacDatabase extends Construct {
       this._pgBouncerServer.node.addDependency(bootstrapper);
 
       this.pgstacSecret = this._pgBouncerServer.pgbouncerSecret;
-
       this.connectionTarget = this._pgBouncerServer.instance;
-
       this.securityGroup = this._pgBouncerServer.securityGroup;
     } else {
       this.connectionTarget = this.db;


### PR DESCRIPTION
## :warning: Checklist if your PR is changing anything else than documentation
- [x] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction)

https://github.com/developmentseed/eoapi-cdk/actions/runs/13120415931/job/36604792924

## Merge request description
Without adding adding this dependency it can be possible to for downstream constructs to try using the new secret before it has been updated!