### PR TITLE
fix: ensure db bootstrapper runs on each deploy

### DIFF
--- a/lib/ingestor-api/runtime/requirements.txt
+++ b/lib/ingestor-api/runtime/requirements.txt
@@ -3,7 +3,7 @@ cachetools==5.3.0
 fastapi>=0.75.1
 orjson>=3.6.8
 psycopg[binary,pool]>=3.0.15
-pydantic_ssm_settings>=0.2.0
+pydantic_ssm_settings>=0.2.0,<1.0
 pydantic>=1.9.0
 pypgstac==0.8.5
 requests>=2.27.1


### PR DESCRIPTION
fix: ensure db bootstrapper runs on each deploy

fix: advertise secretBootstrapper so other resources can use it as a dependency

## :warning: Checklist if your PR is changing anything else than documentation
- [ ] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction)

## Merge request description
This ensures that the bootstrapper `CustomResource` will run on every deploy, which will ensure that any changes to the bootstrap process get executed rather than just updating the Lambda and not invoking it. resolves #113.

I also added the `secretBootstrapper` attribute so other constructs can add it as a dependency (resolves #123)
