### PR TITLE
chore: update ingestor-api runtime dependencies

### DIFF
--- a/lib/ingestor-api/runtime/requirements.txt
+++ b/lib/ingestor-api/runtime/requirements.txt
@@ -3,7 +3,7 @@ cachetools==5.3.0
 fastapi>=0.75.1
 orjson>=3.6.8
 psycopg[binary,pool]>=3.0.15
-pydantic_ssm_settings>=0.2.0,<1.0
+pydantic_ssm_settings>=1.0,<2.0
 pydantic>=1.9.0
 pypgstac==0.8.5
 requests>=2.27.1

--- a/lib/ingestor-api/runtime/requirements.txt
+++ b/lib/ingestor-api/runtime/requirements.txt
@@ -7,5 +7,4 @@ pydantic_ssm_settings>=0.2.0,<1.0
 pydantic>=1.9.0
 pypgstac==0.8.5
 requests>=2.27.1
-# Waiting for https://github.com/stac-utils/stac-pydantic/pull/116
-stac-pydantic @ git+https://github.com/alukach/stac-pydantic.git@patch-1
+stac-pydantic>=3.0

--- a/lib/ingestor-api/runtime/requirements.txt
+++ b/lib/ingestor-api/runtime/requirements.txt
@@ -7,4 +7,4 @@ pydantic_ssm_settings>=1.0,<2.0
 pydantic>=1.9.0
 pypgstac==0.8.5
 requests>=2.27.1
-stac-pydantic>=3.0
+stac-pydantic>=3.0,<4.0

--- a/lib/ingestor-api/runtime/src/config.py
+++ b/lib/ingestor-api/runtime/src/config.py
@@ -2,10 +2,11 @@ import os
 from getpass import getuser
 from typing import Optional
 
-from pydantic import AnyHttpUrl, BaseSettings, Field, constr
-from pydantic_ssm_settings import AwsSsmSourceConfig
+from pydantic import AnyHttpUrl, Field, constr
+from pydantic_settings import BaseSettings
+from pydantic_ssm_settings.settings import SsmBaseSettings
 
-AwsArn = constr(regex=r"^arn:aws:iam::\d{12}:role/.+")
+AwsArn = constr(pattern=r"^arn:aws:iam::\d{12}:role/.+")
 
 
 class Settings(BaseSettings):
@@ -27,8 +28,8 @@ class Settings(BaseSettings):
         description="Path from where to serve this URL.", default=False
     )
 
-    class Config(AwsSsmSourceConfig):
-        env_file = ".env"
+    class Config(SsmBaseSettings):
+        env_file: str = ".env"
 
     @classmethod
     def from_ssm(cls, stack: str):

--- a/lib/ingestor-api/runtime/tests/conftest.py
+++ b/lib/ingestor-api/runtime/tests/conftest.py
@@ -21,6 +21,7 @@ def test_environ():
     os.environ["STAC_URL"] = "https://test-stac.url"
     os.environ["DATA_ACCESS_ROLE"] = "arn:aws:iam::123456789012:role/test-role"
     os.environ["DB_SECRET_ARN"] = "testing"
+    os.environ["ROOT_PATH"] = "testing"
 
 
 @pytest.fixture
@@ -259,7 +260,7 @@ def stac_collection(example_stac_collection):
     return schemas.StacCollection(**example_stac_collection)
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def example_ingestion(example_stac_item):
     from src import schemas
 
@@ -267,5 +268,5 @@ def example_ingestion(example_stac_item):
         id=example_stac_item["id"],
         created_by="test-user",
         status=schemas.Status.queued,
-        item=Item.parse_obj(example_stac_item),
+        item=Item.model_validate(example_stac_item),
     )

--- a/lib/ingestor-api/runtime/tests/test_registration.py
+++ b/lib/ingestor-api/runtime/tests/test_registration.py
@@ -74,7 +74,6 @@ class TestCreate:
         )
 
         assert response.status_code == 201
-        print("item's collection", self.example_ingestion.item.collection)
         collection_exists.assert_called_once_with(
             collection_id=self.example_ingestion.item.collection
         )

--- a/lib/ingestor-api/runtime/tests/test_registration.py
+++ b/lib/ingestor-api/runtime/tests/test_registration.py
@@ -75,7 +75,9 @@ class TestCreate:
 
         assert response.status_code == 201
         print("item's collection", self.example_ingestion.item.collection)
-        collection_exists.assert_called_once_with(self.example_ingestion.item.collection)
+        collection_exists.assert_called_once_with(
+            collection_id=self.example_ingestion.item.collection
+        )
 
         stored_data = self.db.fetch_many(status="queued")["items"]
         assert len(stored_data) == 1

--- a/lib/ingestor-api/runtime/tests/test_registration.py
+++ b/lib/ingestor-api/runtime/tests/test_registration.py
@@ -74,7 +74,8 @@ class TestCreate:
         )
 
         assert response.status_code == 201
-        assert collection_exists.called_once_with(self.example_ingestion.item.collection)
+        print("item's collection", self.example_ingestion.item.collection)
+        collection_exists.assert_called_once_with(self.example_ingestion.item.collection)
 
         stored_data = self.db.fetch_many(status="queued")["items"]
         assert len(stored_data) == 1
@@ -87,7 +88,6 @@ class TestCreate:
             ingestion_endpoint,
             json=jsonable_encoder(self.example_ingestion.item),
         )
-
         collection_missing.assert_called_once_with(
             collection_id=self.example_ingestion.item.collection
         )
@@ -140,7 +140,7 @@ class TestList:
     def populate_table(self, count=100) -> List["schemas.Ingestion"]:
         example_ingestions = []
         for i in range(count):
-            ingestion = self.example_ingestion.copy()
+            ingestion = self.example_ingestion.model_copy()
             ingestion.id = str(i)
             ingestion.created_at = ingestion.created_at + timedelta(hours=i)
             self.mock_table.put_item(Item=ingestion.dynamodb_dict())

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ passenv = AWS_DEFAULT_REGION
 commands =
       pip install -r ./lib/ingestor-api/runtime/requirements.txt
       pip install -r ./lib/ingestor-api/runtime/dev_requirements.txt
-      python -m pytest -s
+      python -m pytest -s -vv
 
 [pytest]
 addopts = -ra -q


### PR DESCRIPTION
## :warning: Checklist if your PR is changing anything else than documentation
- [ ] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction)

## Merge request description
The ingestor API has several out-of-date dependencies that are holding things back - this brings the ingestor runtime up to pydantic >= 2 and stac-pydantic >= 3

Resolves #119 