### PR TITLE
fix: use model_dump(mode="json") for serializing STAC objects

### DIFF
--- a/lib/ingestor-api/runtime/src/collection.py
+++ b/lib/ingestor-api/runtime/src/collection.py
@@ -24,7 +24,7 @@ def ingest(collection: StacCollection):
             )
     except Exception as e:
         raise HTTPException(
-            status_code=400,
+            status_code=500,
             detail=f"Encountered failure loading collection into pgSTAC: {e}",
         ) from e
 

--- a/lib/ingestor-api/runtime/src/utils.py
+++ b/lib/ingestor-api/runtime/src/utils.py
@@ -2,7 +2,6 @@ from typing import Sequence
 
 import boto3
 import pydantic
-from fastapi.encoders import jsonable_encoder
 from pypgstac.db import PgstacDB
 from pypgstac.load import Methods
 
@@ -41,8 +40,7 @@ def load_items(creds: DbCreds, ingestions: Sequence[Ingestion]):
     with PgstacDB(dsn=creds.dsn_string, debug=True) as db:
         loader = Loader(db=db)
 
-        # serialize to JSON-friendly dicts (won't be necessary in Pydantic v2, https://github.com/pydantic/pydantic/issues/1409#issuecomment-1423995424)
-        items = jsonable_encoder(i.item for i in ingestions)
+        items = [i.item.model_dump(mode="json") for i in ingestions]
         loading_result = loader.load_items(
             file=items,
             # use insert_ignore to avoid overwritting existing items or upsert to replace

--- a/lib/ingestor-api/runtime/tests/test_collection.py
+++ b/lib/ingestor-api/runtime/tests/test_collection.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 import src.collection as collection
+from fastapi import HTTPException
 from pypgstac.load import Methods
 from src.utils import DbCreds
 
@@ -31,6 +32,31 @@ def test_load_collections(stac_collection, loader, pgstacdb):
         collection.ingest(stac_collection)
 
     loader.return_value.load_collections.assert_called_once_with(
-        file=[stac_collection.to_dict()],
+        file=[stac_collection.model_dump(mode="json")],
         insert_mode=Methods.upsert,
     )
+
+
+def test_ingest_loader_error(stac_collection, pgstacdb):
+    """Test handling of errors during the loading process."""
+    with patch(
+        "src.collection.get_db_credentials",
+        return_value=DbCreds(
+            username="", password="", host="", port=1, dbname="", engine=""
+        ),
+    ):
+        os.environ["DB_SECRET_ARN"] = ""
+
+        # Mock the loader to raise an exception
+        with patch("src.collection.Loader") as mock_loader:
+            mock_loader_instance = Mock()
+            mock_loader.return_value = mock_loader_instance
+            mock_loader_instance.load_collections.side_effect = Exception(
+                "Invalid collection data"
+            )
+
+            with pytest.raises(HTTPException) as excinfo:
+                collection.ingest(stac_collection)
+
+            assert excinfo.value.status_code == 400
+            assert "Invalid collection data" in str(excinfo.value.detail)

--- a/lib/ingestor-api/runtime/tests/test_utils.py
+++ b/lib/ingestor-api/runtime/tests/test_utils.py
@@ -1,7 +1,6 @@
 from unittest.mock import Mock, patch
 
 import pytest
-from fastapi.encoders import jsonable_encoder
 from pypgstac.load import Methods
 from src.utils import DbCreds
 
@@ -28,8 +27,9 @@ def dbcreds():
 def test_load_items(loader, pgstacdb, example_ingestion, dbcreds):
     import src.utils as utils
 
-    utils.load_items(dbcreds, [example_ingestion])
+    ingestions = [example_ingestion]
+    utils.load_items(dbcreds, ingestions)
     loader.return_value.load_items.assert_called_once_with(
-        file=jsonable_encoder([example_ingestion.item]),
+        file=[i.item.model_dump(mode="json") for i in ingestions],
         insert_mode=Methods.upsert,
     )


### PR DESCRIPTION
resolves #130

## :warning: Checklist if your PR is changing anything else than documentation
- [x] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction) https://github.com/developmentseed/eoapi-cdk/actions/runs/13707782964/job/38337193745

## Merge request description
We did not have coverage for the case where a collection object is not JSON serializable. This fixes a bug with the pydantic>=2 upgrade and adds a test.