### PR TITLE
fix: reject items without a collection ID

### DIFF
--- a/lib/ingestor-api/runtime/src/schemas.py
+++ b/lib/ingestor-api/runtime/src/schemas.py
@@ -43,6 +43,7 @@ class AccessibleAsset(shared.Asset):
 
 class AccessibleItem(Item):
     assets: Dict[str, AccessibleAsset]
+    collection: str  # override because default is str | None
 
     @field_validator("collection")
     def exists(cls, collection):

--- a/lib/ingestor-api/runtime/tests/test_registration.py
+++ b/lib/ingestor-api/runtime/tests/test_registration.py
@@ -93,9 +93,24 @@ class TestCreate:
             collection_id=self.example_ingestion.item.collection
         )
         assert response.status_code == 422, "should get validation error"
-        assert (
-            len(self.db.fetch_many(status="queued")["items"]) == 0
-        ), "data should not be stored in DB"
+        assert len(self.db.fetch_many(status="queued")["items"]) == 0, (
+            "data should not be stored in DB"
+        )
+
+    def test_validates_no_collection_id(
+        self, client_authenticated, collection_exists, asset_exists
+    ):
+        item_sans_id = self.example_ingestion.item.model_copy()
+        item_sans_id.collection = None
+
+        response = self.api_client.post(
+            ingestion_endpoint,
+            json=item_sans_id.model_dump(mode="json"),
+        )
+        assert response.status_code == 422, "should get validation error"
+        assert len(self.db.fetch_many(status="queued")["items"]) == 0, (
+            "data should not be stored in DB"
+        )
 
     def test_validates_missing_assets(
         self, client_authenticated, collection_exists, asset_missing
@@ -121,9 +136,9 @@ class TestCreate:
                 err["loc"] == ["body", "assets", asset_type, "href"]
                 for err in response.json()["detail"]
             ), "should reference asset type in validation error response"
-        assert (
-            len(self.db.fetch_many(status="queued")["items"]) == 0
-        ), "data should not be stored in DB"
+        assert len(self.db.fetch_many(status="queued")["items"]) == 0, (
+            "data should not be stored in DB"
+        )
 
 
 class TestList:


### PR DESCRIPTION
## Merge request description
Right now a user could POST a STAC item without the collection ID field set and the server would hit a 500 error when it tries to find `{stac_endpoint}/collections/None`. This change will instantly reject a STAC item with a missing collection ID!

resolves #132 