### PR TITLE
fix: disable transaction extensions by default

### DIFF
--- a/integration_tests/cdk/app.py
+++ b/integration_tests/cdk/app.py
@@ -81,7 +81,7 @@ class pgStacInfraStack(Stack):
             instance_type=aws_ec2.InstanceType(app_config.db_instance_type),
             add_pgbouncer=True,
             removal_policy=RemovalPolicy.DESTROY,
-            pgstac_version="0.9.2",
+            pgstac_version="0.9.5",
         )
 
         assert pgstac_db.security_group


### PR DESCRIPTION
## :warning: Checklist if your PR is changing anything else than documentation
- [x] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction) I deployed to my non-ephemeral stack with these changes.

## Merge request description
The transaction extension is not something we want to enable without an auth layer! This adds a field to the `PgStacApiLambdaProps` for providing a list of enabled extensions. It defaults to all of the extensions supported by stac-fastapi-pgstac except for the transaction and bulk transactions extensions.

Resolves #134 