### PR TITLE
fix: refactor to keep database pgstac and ingestor pypgstac in sync

### DIFF
--- a/integration_tests/cdk/app.py
+++ b/integration_tests/cdk/app.py
@@ -160,6 +160,9 @@ class pgStacInfraStack(Stack):
             stac_url=stac_api.url,
             stage="test",
             pgstac_version=PGSTAC_VERSION,
+            api_env={
+                "JWKS_URL": "",  # no authentication!
+            },
         )
 
 

--- a/lib/database/index.ts
+++ b/lib/database/index.ts
@@ -10,11 +10,10 @@ import {
   aws_logs,
 } from "aws-cdk-lib";
 import { Construct } from "constructs";
-import { CustomLambdaFunctionProps } from "../utils";
+import { CustomLambdaFunctionProps, DEFAULT_PGSTAC_VERSION } from "../utils";
 import { PgBouncer } from "./PgBouncer";
 
 const instanceSizes: Record<string, number> = require("./instance-memory.json");
-const DEFAULT_PGSTAC_VERSION = "0.9.5";
 
 let defaultPgSTACCustomOptions: { [key: string]: any } = {
   context: "FALSE",

--- a/lib/ingestor-api/runtime/Dockerfile
+++ b/lib/ingestor-api/runtime/Dockerfile
@@ -1,4 +1,5 @@
 ARG PYTHON_VERSION
+
 FROM --platform=linux/amd64 public.ecr.aws/lambda/python:${PYTHON_VERSION}
 
 WORKDIR /tmp
@@ -8,7 +9,10 @@ RUN yum install -y git
 RUN python -m pip install pip -U
 
 COPY runtime/requirements.txt requirements.txt
-RUN python -m pip install -r requirements.txt "mangum>=0.14,<0.15" -t /asset --no-binary pydantic
+
+ARG PGSTAC_VERSION=0.9.5
+RUN echo "pypgstac==${PGSTAC_VERSION}" > constraints.txt
+RUN python -m pip install -r requirements.txt -c constraints.txt "mangum>=0.14,<0.15" -t /asset --no-binary pydantic
 
 RUN mkdir -p /asset/src
 COPY runtime/src/*.py /asset/src/

--- a/lib/ingestor-api/runtime/Dockerfile
+++ b/lib/ingestor-api/runtime/Dockerfile
@@ -10,7 +10,7 @@ RUN python -m pip install pip -U
 
 COPY runtime/requirements.txt requirements.txt
 
-ARG PGSTAC_VERSION=0.9.5
+ARG PGSTAC_VERSION
 RUN echo "pypgstac==${PGSTAC_VERSION}" > constraints.txt
 RUN python -m pip install -r requirements.txt -c constraints.txt "mangum>=0.14,<0.15" -t /asset --no-binary pydantic
 

--- a/lib/ingestor-api/runtime/requirements.txt
+++ b/lib/ingestor-api/runtime/requirements.txt
@@ -5,6 +5,6 @@ orjson>=3.6.8
 psycopg[binary,pool]>=3.0.15
 pydantic_ssm_settings>=1.0,<2.0
 pydantic>=1.9.0
-pypgstac==0.8.5
+pypgstac
 requests>=2.27.1
 stac-pydantic>=3.0,<4.0

--- a/lib/ingestor-api/runtime/src/config.py
+++ b/lib/ingestor-api/runtime/src/config.py
@@ -22,7 +22,8 @@ class Settings(BaseSettings):
     root_path: Optional[str] = Field(description="Path from where to serve this URL.")
 
     jwks_url: Optional[HttpUrlString] = Field(
-        description="URL of JWKS, e.g. https://cognito-idp.{region}.amazonaws.com/{userpool_id}/.well-known/jwks.json"  # noqa
+        default=None,
+        description="URL of JWKS, e.g. https://cognito-idp.{region}.amazonaws.com/{userpool_id}/.well-known/jwks.json",  # noqa
     )
 
     stac_url: HttpUrlString = Field(description="URL of STAC API")

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,5 +1,4 @@
-import {
-    aws_lambda as lambda,
-  } from "aws-cdk-lib";
+import { aws_lambda as lambda } from "aws-cdk-lib";
 
 export type CustomLambdaFunctionProps = lambda.FunctionProps | any;
+export const DEFAULT_PGSTAC_VERSION = "0.9.5";


### PR DESCRIPTION
## :warning: Checklist if your PR is changing anything else than documentation
- [x] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction) https://github.com/developmentseed/eoapi-cdk/actions/runs/13787766250

## Merge request description
It is important for the ingestor API and the database to have the same version of pgstac/pypgstac. This moves the pypgstac version out of a hard-coded value in requirements.txt and into a configurable argument that is easier to keep in sync with the database.

I also added an ingestor deployment to the test deployment CDK app, which should pave the way for #117 