### PR TITLE
refactor: permit usage of higher CDK versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,9 @@
       "name": "eoapi-cdk",
       "version": "8.0.2",
       "license": "ISC",
-      "dependencies": {
-        "@aws-cdk/aws-apigatewayv2-alpha": "2.114.1-alpha.0",
-        "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.114.1-alpha.0",
-        "aws-cdk-lib": "2.130.0",
-        "constructs": "10.3.0"
-      },
       "devDependencies": {
         "@aws-cdk/aws-apigatewayv2-alpha": "2.114.1-alpha.0",
+        "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.114.1-alpha.0",
         "@qiwi/semantic-release-gh-pages-plugin": "^5.2.3",
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/git": "^10.0.1",
@@ -31,30 +26,35 @@
         "semantic-release": "^19.0.5"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-apigatewayv2-alpha": "2.114.1-alpha.0",
-        "aws-cdk-lib": "2.130.0",
-        "constructs": "10.3.0"
+        "@aws-cdk/aws-apigatewayv2-alpha": "^2.114.1-alpha.0",
+        "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.114.1-alpha.0",
+        "aws-cdk-lib": "^2.130.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
       "version": "2.2.202",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz",
-      "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg=="
+      "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg==",
+      "dev": true
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
-      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
+      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg==",
+      "dev": true
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
-      "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
+      "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg==",
+      "dev": true
     },
     "node_modules/@aws-cdk/aws-apigatewayv2-alpha": {
       "version": "2.114.1-alpha.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-alpha/-/aws-apigatewayv2-alpha-2.114.1-alpha.0.tgz",
       "integrity": "sha512-+urpw7rGrtdGvnHQlDXVfpI3TmQJpjuT9jTOeuuG5dNDczLJrUokBvQdj6H6KsngdmBC07WfWU+yL2MBp71ozA==",
+      "dev": true,
       "engines": {
         "node": ">= 14.15.0"
       },
@@ -67,6 +67,7 @@
       "version": "2.114.1-alpha.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-integrations-alpha/-/aws-apigatewayv2-integrations-alpha-2.114.1-alpha.0.tgz",
       "integrity": "sha512-iB7vHoTguDKLeatJS4p/8OBqH4oLCG2xBn1toUFwMD9iWoRGahGiK0pYuq24baab3SuNS1LFThJw5Zu0R+cZGA==",
+      "dev": true,
       "engines": {
         "node": ">= 14.15.0"
       },
@@ -1116,6 +1117,7 @@
         "yaml",
         "mime-types"
       ],
+      "dev": true,
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "^2.2.202",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
@@ -1141,11 +1143,13 @@
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
       "version": "8.12.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1161,6 +1165,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
       "version": "5.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1169,6 +1174,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1183,6 +1189,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/astral-regex": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1191,11 +1198,13 @@
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1205,6 +1214,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/case": {
       "version": "1.6.3",
+      "dev": true,
       "inBundle": true,
       "license": "(MIT OR GPL-3.0-or-later)",
       "engines": {
@@ -1213,6 +1223,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1224,26 +1235,31 @@
     },
     "node_modules/aws-cdk-lib/node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
       "version": "8.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
       "version": "11.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1257,11 +1273,13 @@
     },
     "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
       "version": "4.2.11",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
       "version": "5.3.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1270,6 +1288,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1278,11 +1297,13 @@
     },
     "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1294,6 +1315,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
       "version": "1.4.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1302,11 +1324,13 @@
     },
     "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
       "version": "4.4.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1318,6 +1342,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/mime-db": {
       "version": "1.52.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1326,6 +1351,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/mime-types": {
       "version": "2.1.35",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1337,6 +1363,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
       "version": "3.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1348,6 +1375,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
       "version": "2.3.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1356,6 +1384,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/require-from-string": {
       "version": "2.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1364,6 +1393,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
       "version": "7.6.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1378,6 +1408,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1394,6 +1425,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/string-width": {
       "version": "4.2.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1407,6 +1439,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1418,6 +1451,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
       "version": "6.8.1",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1433,6 +1467,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1441,6 +1476,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/uri-js": {
       "version": "4.4.1",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -1449,11 +1485,13 @@
     },
     "node_modules/aws-cdk-lib/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
       "version": "1.10.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -1835,6 +1873,7 @@
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.3.0.tgz",
       "integrity": "sha512-vbK8i3rIb/xwZxSpTjz3SagHn1qq9BChLEfy5Hf6fB3/2eFbrwt2n9kHwQcS0CPTRBesreeAcsJfMq2229FnbQ==",
+      "dev": true,
       "engines": {
         "node": ">= 16.14.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,8 @@
         "semantic-release": "^19.0.5"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-apigatewayv2-alpha": "^2.114.1-alpha.0",
-        "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.114.1-alpha.0",
+        "@aws-cdk/aws-apigatewayv2-alpha": "2.114.1-alpha.0",
+        "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.114.1-alpha.0",
         "aws-cdk-lib": "^2.130.0",
         "constructs": "^10.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "semantic-release": "^19.0.5"
   },
   "peerDependencies": {
-    "@aws-cdk/aws-apigatewayv2-alpha": "^2.114.1-alpha.0",
-    "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.114.1-alpha.0",
+    "@aws-cdk/aws-apigatewayv2-alpha": "2.114.1-alpha.0",
+    "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.114.1-alpha.0",
     "aws-cdk-lib": "^2.130.0",
     "constructs": "^10.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -39,31 +39,27 @@
     }
   },
   "devDependencies": {
+    "@aws-cdk/aws-apigatewayv2-alpha": "2.114.1-alpha.0",
+    "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.114.1-alpha.0",
     "@qiwi/semantic-release-gh-pages-plugin": "^5.2.3",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@types/node": "^18.7.23",
-    "jsii": "5.7.4",
+    "aws-cdk-lib": "2.130.0",
+    "constructs": "10.3.0",
     "jsii-docgen": "10.6.1",
     "jsii-pacmak": "1.106.0",
+    "jsii": "5.7.4",
     "nodemon": "^2.0.20",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
-    "semantic-release": "^19.0.5",
-    "aws-cdk-lib": "2.130.0",
-    "constructs": "10.3.0",
-    "@aws-cdk/aws-apigatewayv2-alpha": "2.114.1-alpha.0"
-  },
-  "dependencies": {
-    "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.114.1-alpha.0",
-    "@aws-cdk/aws-apigatewayv2-alpha": "2.114.1-alpha.0",
-    "aws-cdk-lib": "2.130.0",
-    "constructs": "10.3.0"
+    "semantic-release": "^19.0.5"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "2.130.0",
-    "constructs": "10.3.0",
-    "@aws-cdk/aws-apigatewayv2-alpha": "2.114.1-alpha.0"
+    "@aws-cdk/aws-apigatewayv2-alpha": "^2.114.1-alpha.0",
+    "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.114.1-alpha.0",
+    "aws-cdk-lib": "^2.130.0",
+    "constructs": "^10.3.0"
   },
   "release": {
     "branches": [


### PR DESCRIPTION
## :warning: Checklist if your PR is changing anything else than documentation
- [x] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction)

> [!NOTE]
> Successful build: https://github.com/developmentseed/eoapi-cdk/actions/runs/14480817992/job/40617191146

## Merge request description

I am trying to use `eoapi-cdk` on a project but find am unable to upgrade CDK beyond `2.130.0`:

```
▶ uv sync
  × No solution found when resolving dependencies:
  ╰─▶ Because only eoapi-cdk<=8.0.2 is available and eoapi-cdk==8.0.2 depends on aws-cdk-lib==2.130.0, we can conclude that eoapi-cdk>=8.0.2 depends on
      aws-cdk-lib==2.130.0.
      And because my-project-aws depends on aws-cdk-lib>=2.189.0, we can conclude that -project-aws and eoapi-cdk>=8.0.2 are incompatible.
      And because -project-aws depends on eoapi-cdk>=8.0.2 and your workspace requires -project-aws, we can conclude that your
      workspace's requirements are unsatisfiable.
```

I would prefer to use the latest version of CDK (`2.189.0`).

This PR refactors the dependency declarations in `package.json` to follow best practices for CDK construct libraries[^1]:

> In `peerDependencies`, use a caret (^) to specify the lowest version of `aws-cdk-lib` that your library works with. This maximizes the compatibility of your library with a range of CDK versions. Specify exact versions for alpha construct library modules, which have APIs that may change. Using `peerDependencies` makes sure that there is only one copy of all CDK libraries in the `node_modules` tree.

> In `devDependencies`, specify the tools and libraries you need for testing, optionally with ^ to indicate that later compatible versions are acceptable. Specify exactly (without ^ or ~) the lowest versions of `aws-cdk-lib` and other CDK packages that you advertise your library be compatible with. This practice makes sure that your tests run against those versions. This way, if you inadvertently use a feature found only in newer versions, your tests can catch it.

[^1]: https://docs.aws.amazon.com/cdk/v2/guide/work-with-cdk-typescript.html#work-with-cdk-typescript-dependencies-libraries

closes #141