### PR TITLE
fix: update tipg startup for 1.0

### DIFF
--- a/lib/tipg-api/runtime/src/handler.py
+++ b/lib/tipg-api/runtime/src/handler.py
@@ -6,31 +6,24 @@ import asyncio
 import os
 
 from mangum import Mangum
+from tipg.collections import register_collection_catalog
+from tipg.database import connect_to_db
+from tipg.main import app
+from tipg.settings import (
+    CustomSQLSettings,
+    DatabaseSettings,
+    PostgresSettings,
+)
 from utils import get_secret_dict
 
 secret = get_secret_dict(secret_arn_env_var="PGSTAC_SECRET_ARN")
-os.environ.update(
-    {
-        "postgres_host": secret["host"],
-        "postgres_dbname": secret["dbname"],
-        "postgres_user": secret["username"],
-        "postgres_pass": secret["password"],
-        "postgres_port": str(secret["port"]),
-    }
+postgres_settings = PostgresSettings(
+    postgres_host=secret["host"],
+    postgres_dbname=secret["dbname"],
+    postgres_user=secret["username"],
+    postgres_pass=secret["password"],
+    postgres_port=int(secret["port"]),
 )
-
-from tipg.collections import register_collection_catalog  # noqa: E402
-from tipg.database import connect_to_db  # noqa: E402
-
-# skipping linting rule that wants all imports at the top
-from tipg.main import app  # noqa: E402
-from tipg.settings import (
-    CustomSQLSettings,  # noqa: E402
-    DatabaseSettings,  # noqa: E402
-    PostgresSettings,  # noqa: E402; noqa: E402
-)
-
-postgres_settings = PostgresSettings()
 db_settings = DatabaseSettings()
 custom_sql_settings = CustomSQLSettings()
 
@@ -40,20 +33,14 @@ async def startup_event() -> None:
     """Connect to database on startup."""
     await connect_to_db(
         app,
-        settings=postgres_settings,
         schemas=db_settings.schemas,
+        tipg_schema=db_settings.tipg_schema,
         user_sql_files=custom_sql_settings.sql_files,
+        settings=postgres_settings,
     )
     await register_collection_catalog(
         app,
-        schemas=db_settings.schemas,
-        tables=db_settings.tables,
-        exclude_tables=db_settings.exclude_tables,
-        exclude_table_schemas=db_settings.exclude_table_schemas,
-        functions=db_settings.functions,
-        exclude_functions=db_settings.exclude_functions,
-        exclude_function_schemas=db_settings.exclude_function_schemas,
-        spatial=db_settings.only_spatial_tables,
+        db_settings=db_settings,
     )
 
 


### PR DESCRIPTION
resolves #143

## :warning: Checklist if your PR is changing anything else than documentation
- [x] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction)
https://github.com/developmentseed/eoapi-cdk/actions/runs/14491012794/job/40647272705

## Merge request description
I missed the tipg API update when updating handlers for the latest versions. This solves it and updates the titiler-pgstac handler to avoid setting postgres variables via `os.environ`.