### PR TITLE
fix: upgrade pgbouncer ami to ubuntu 24.04

### DIFF
--- a/lib/database/PgBouncer.ts
+++ b/lib/database/PgBouncer.ts
@@ -147,7 +147,7 @@ export class PgBouncer extends Construct {
           : ec2.SubnetType.PRIVATE_WITH_EGRESS,
       },
       machineImage: ec2.MachineImage.fromSsmParameter(
-        "/aws/service/canonical/ubuntu/server/jammy/stable/current/amd64/hvm/ebs-gp2/ami-id",
+        "/aws/service/canonical/ubuntu/server/noble/stable/current/amd64/hvm/ebs-gp3/ami-id",
         { os: ec2.OperatingSystemType.LINUX }
       ),
       blockDevices: [

--- a/lib/database/pgbouncer-setup.sh
+++ b/lib/database/pgbouncer-setup.sh
@@ -19,7 +19,6 @@ curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 
 # Install required packages
-apt-get update
 
 # Function that makes sure we don't hit a dpkg lock error
 wait_for_dpkg_lock() {
@@ -30,7 +29,12 @@ wait_for_dpkg_lock() {
 }
 
 wait_for_dpkg_lock
-DEBIAN_FRONTEND=noninteractive apt-get install -y pgbouncer jq awscli
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get upgrade -y
+apt-get install -y pgbouncer jq
+snap install aws-cli --classic
 
 echo "Fetching secret from ARN: ${SECRET_ARN}"
 


### PR DESCRIPTION
## :warning: Checklist if your PR is changing anything else than documentation
- [ ] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction)

I also manually deployed a stack and verified that the pgbouncer service is working correctly after this change.

## Merge request description
This helps reduce security vulnerabilities for the pgbouncer EC2 instance by upgrading to Ubuntu 24.04 and running `apt-get update` and `apt-get upgrade` to ensure that the latest packages are installed when the instance boots up.