### PR TITLE
fix: add option to create collection if missing

### DIFF
--- a/lib/stac-item-loader/index.ts
+++ b/lib/stac-item-loader/index.ts
@@ -122,6 +122,10 @@ export interface StacItemLoaderProps {
    *
    * These will be merged with the default environment variables including
    * PGSTAC_SECRET_ARN. Use this for custom configuration or debugging flags.
+   *
+   * If you want to enable the option to upload a boilerplate collection record
+   * in the event that the collection record does not yet exist for an item that
+   * is set to be loaded, set the variable `"CREATE_COLLECTIONS_IF_MISSING": "TRUE"`.
    */
   readonly environment?: { [key: string]: string };
 }


### PR DESCRIPTION
## Merge request description
Enable a boilerplate collection record to be uploaded when an item's collection is not yet present in the database.