### PR TITLE
feat: Expose API runtime constructs

### DIFF
--- a/lib/stac-api/index.ts
+++ b/lib/stac-api/index.ts
@@ -8,11 +8,7 @@ import {
   aws_logs,
 } from "aws-cdk-lib";
 import { Construct } from "constructs";
-import {
-  CustomLambdaFunctionProps,
-  LambdaApiGateway,
-  LambdaApiGatewayProps,
-} from "../utils";
+import { CustomLambdaFunctionProps, LambdaApiGateway } from "../utils";
 import * as path from "path";
 
 export const EXTENSIONS = {
@@ -168,7 +164,7 @@ export class PgStacApiLambda extends Construct {
 
     const api = new LambdaApiGateway(this, "stac-api", {
       lambdaFunction: runtime.stacApiLambdaFunction,
-      domainName: props.domainName,
+      domainName: props.stacApiDomainName,
       outputName: "url",
     });
 
@@ -176,6 +172,11 @@ export class PgStacApiLambda extends Construct {
   }
 }
 
-export interface PgStacApiLambdaProps
-  extends PgStacApiLambdaRuntimeProps,
-    Omit<LambdaApiGatewayProps, "lambdaFunction"> {}
+export interface PgStacApiLambdaProps extends PgStacApiLambdaRuntimeProps {
+  /**
+   * Custom Domain Name Options for Titiler Pgstac API,
+   *
+   * @default - undefined.
+   */
+  readonly stacApiDomainName?: apigatewayv2.IDomainName;
+}

--- a/lib/tipg-api/index.ts
+++ b/lib/tipg-api/index.ts
@@ -14,118 +14,173 @@ import { Construct } from "constructs";
 import { CustomLambdaFunctionProps } from "../utils";
 import * as path from 'path';
 
-  export class TiPgApiLambda extends Construct {
-    readonly url: string;
-    public tiPgLambdaFunction: lambda.Function;
+export class TiPgApiLambdaRuntime extends Construct {
+  public readonly tiPgLambdaFunction: lambda.Function;
 
-    constructor(scope: Construct, id: string, props: TiPgApiLambdaProps) {
-      super(scope, id);
+  constructor(scope: Construct, id: string, props: TiPgApiLambdaRuntimeProps) {
+    super(scope, id);
 
-      this.tiPgLambdaFunction = new lambda.Function(this, "lambda", {
-        // defaults
-        runtime: lambda.Runtime.PYTHON_3_11,
-        handler: "handler.handler",
-        memorySize: 1024,
-        logRetention: logs.RetentionDays.ONE_WEEK,
-        timeout: Duration.seconds(30),
-        code: lambda.Code.fromDockerBuild(path.join(__dirname, '..'), {
-          file: "tipg-api/runtime/Dockerfile",
-          buildArgs: { PYTHON_VERSION: '3.11' },
-        }),
-        vpc: props.vpc,
-        vpcSubnets: props.subnetSelection,
-        allowPublicSubnet: true,
-        environment: {
-          PGSTAC_SECRET_ARN: props.dbSecret.secretArn,
-          DB_MIN_CONN_SIZE: "1",
-          DB_MAX_CONN_SIZE: "1",
-          ...props.apiEnv,
-        },
-        // overwrites defaults with user-provided configurable properties
-        ...props.lambdaFunctionOptions
-      });
+    this.tiPgLambdaFunction = new lambda.Function(this, "lambda", {
+      // defaults
+      runtime: lambda.Runtime.PYTHON_3_11,
+      handler: "handler.handler",
+      memorySize: 1024,
+      logRetention: logs.RetentionDays.ONE_WEEK,
+      timeout: Duration.seconds(30),
+      code: lambda.Code.fromDockerBuild(path.join(__dirname, ".."), {
+        file: "tipg-api/runtime/Dockerfile",
+        buildArgs: { PYTHON_VERSION: "3.11" },
+      }),
+      vpc: props.vpc,
+      vpcSubnets: props.subnetSelection,
+      allowPublicSubnet: true,
+      environment: {
+        PGSTAC_SECRET_ARN: props.dbSecret.secretArn,
+        DB_MIN_CONN_SIZE: "1",
+        DB_MAX_CONN_SIZE: "1",
+        ...props.apiEnv,
+      },
+      // overwrites defaults with user-provided configurable properties
+      ...props.lambdaFunctionOptions,
+    });
 
-      props.dbSecret.grantRead(this.tiPgLambdaFunction);
+    props.dbSecret.grantRead(this.tiPgLambdaFunction);
 
-      if (props.vpc){
-        this.tiPgLambdaFunction.connections.allowTo(props.db, ec2.Port.tcp(5432), "allow connections from tipg");
-      }
-
-      const tipgApi = new apigatewayv2.HttpApi(
-        this,
-        `${Stack.of(this).stackName}-tipg-api`,
-        {
-          defaultDomainMapping: props.tipgApiDomainName
-            ? {
-                domainName: props.tipgApiDomainName,
-              }
-            : undefined,
-          defaultIntegration:
-            new apigatewayv2_integrations.HttpLambdaIntegration(
-              "integration",
-              this.tiPgLambdaFunction,
-              props.tipgApiDomainName
-                ? {
-                    parameterMapping:
-                      new apigatewayv2.ParameterMapping().overwriteHeader(
-                        "host",
-                        apigatewayv2.MappingValue.custom(
-                          props.tipgApiDomainName.name
-                        )
-                      ),
-                  }
-                : undefined
-            ),
-        }
+    if (props.vpc) {
+      this.tiPgLambdaFunction.connections.allowTo(
+        props.db,
+        ec2.Port.tcp(5432),
+        "allow connections from tipg"
       );
-
-      this.url = tipgApi.url!;
-
-      new CfnOutput(this, "tipg-api-output", {
-        exportName: `${Stack.of(this).stackName}-tip-url`,
-        value: this.url,
-      });
     }
   }
+}
 
-  export interface TiPgApiLambdaProps {
-    /**
-     * VPC into which the lambda should be deployed.
-     */
-    readonly vpc?: ec2.IVpc;
+export interface TiPgApiLambdaRuntimeProps {
+  /**
+   * VPC into which the lambda should be deployed.
+   */
+  readonly vpc?: ec2.IVpc;
 
-    /**
-     * RDS Instance with installed pgSTAC or pgbouncer server.
-     */
-    readonly db: rds.IDatabaseInstance | ec2.IInstance;
+  /**
+   * RDS Instance with installed pgSTAC or pgbouncer server.
+   */
+  readonly db: rds.IDatabaseInstance | ec2.IInstance;
 
-    /**
-     * Subnet into which the lambda should be deployed.
-     */
-    readonly subnetSelection?: ec2.SubnetSelection;
+  /**
+   * Subnet into which the lambda should be deployed.
+   */
+  readonly subnetSelection?: ec2.SubnetSelection;
 
-    /**
-     * Secret containing connection information for pgSTAC database.
-     */
-    readonly dbSecret: secretsmanager.ISecret;
+  /**
+   * Secret containing connection information for pgSTAC database.
+   */
+  readonly dbSecret: secretsmanager.ISecret;
 
-    /**
-     * Customized environment variables to send to titiler-pgstac runtime.
-     */
-    readonly apiEnv?: Record<string, string>;
+  /**
+   * Customized environment variables to send to titiler-pgstac runtime.
+   */
+  readonly apiEnv?: Record<string, string>;
 
-    /**
-     * Custom Domain Name for tipg API. If defined, will create the
-     * domain name and integrate it with the tipg API.
-     *
-     * @default - undefined
-     */
-    readonly tipgApiDomainName?: apigatewayv2.IDomainName;
+  /**
+   * Can be used to override the default lambda function properties.
+   *
+   * @default - defined in the construct.
+   */
+  readonly lambdaFunctionOptions?: CustomLambdaFunctionProps;
+}
 
-    /**
-     * Can be used to override the default lambda function properties.
-     *
-     * @default - defined in the construct.
-     */
-    readonly lambdaFunctionOptions?: CustomLambdaFunctionProps;
+export class TiPgApiLambdaApiGateway extends Construct {
+  readonly url: string;
+
+  constructor(
+    scope: Construct,
+    id: string,
+    props: TiPgApiLambdaApiGatewayProps
+  ) {
+    super(scope, id);
+
+    const tipgApi = new apigatewayv2.HttpApi(
+      this,
+      `${Stack.of(this).stackName}-tipg-api`,
+      {
+        defaultDomainMapping: props.tipgApiDomainName
+          ? {
+              domainName: props.tipgApiDomainName,
+            }
+          : undefined,
+        defaultIntegration: new apigatewayv2_integrations.HttpLambdaIntegration(
+          "integration",
+          props.lambdaFunction,
+          props.tipgApiDomainName
+            ? {
+                parameterMapping:
+                  new apigatewayv2.ParameterMapping().overwriteHeader(
+                    "host",
+                    apigatewayv2.MappingValue.custom(
+                      props.tipgApiDomainName.name
+                    )
+                  ),
+              }
+            : undefined
+        ),
+      }
+    );
+
+    this.url = tipgApi.url!;
+
+    new CfnOutput(this, "tipg-api-output", {
+      exportName: `${Stack.of(this).stackName}-tip-url`,
+      value: this.url,
+    });
   }
+}
+
+export interface TiPgApiLambdaApiGatewayProps {
+  /**
+   * Lambda function to integrate with the API Gateway.
+   */
+  readonly lambdaFunction: lambda.Function;
+
+  /**
+   * Custom Domain Name for tipg API. If defined, will create the
+   * domain name and integrate it with the tipg API.
+   *
+   * @default - undefined
+   */
+  readonly tipgApiDomainName?: apigatewayv2.IDomainName;
+}
+
+export class TiPgApiLambda extends Construct {
+  readonly url: string;
+  public tiPgLambdaFunction: lambda.Function;
+
+  constructor(scope: Construct, id: string, props: TiPgApiLambdaProps) {
+    super(scope, id);
+
+    const runtime = new TiPgApiLambdaRuntime(this, "runtime", {
+      vpc: props.vpc,
+      subnetSelection: props.subnetSelection,
+      db: props.db,
+      dbSecret: props.dbSecret,
+      apiEnv: props.apiEnv,
+      lambdaFunctionOptions: props.lambdaFunctionOptions,
+    });
+    this.tiPgLambdaFunction = runtime.tiPgLambdaFunction;
+
+    const api = new TiPgApiLambdaApiGateway(this, "api", {
+      lambdaFunction: runtime.tiPgLambdaFunction,
+      tipgApiDomainName: props.tipgApiDomainName,
+    });
+
+    this.url = api.url;
+  }
+}
+
+export interface TiPgApiLambdaProps
+  extends TiPgApiLambdaRuntimeProps,
+    Omit<TiPgApiLambdaApiGatewayProps, "lambdaFunction"> {
+  // This interface combines both runtime and API gateway props
+  // The lambdaFunction property from TiPgApiLambdaApiGatewayProps is excluded
+  // as it will be provided by the runtime construct
+}

--- a/lib/titiler-pgstac-api/index.ts
+++ b/lib/titiler-pgstac-api/index.ts
@@ -13,147 +13,216 @@ import {
 } from "aws-cdk-lib";
 import { Construct } from "constructs";
 import { CustomLambdaFunctionProps } from "../utils";
-import * as path from 'path';
+import * as path from "path";
 
-  // default settings that can be overridden by the user-provided environment.
-  let defaultTitilerPgstacEnv :{ [key: string]: any } = {
-    "CPL_VSIL_CURL_ALLOWED_EXTENSIONS": ".tif,.TIF,.tiff",
-    "GDAL_CACHEMAX": "200",
-    "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
-    "GDAL_INGESTED_BYTES_AT_OPEN": "32768",
-    "GDAL_HTTP_MERGE_CONSECUTIVE_RANGES": "YES",
-    "GDAL_HTTP_MULTIPLEX": "YES",
-    "GDAL_HTTP_VERSION": "2",
-    "PYTHONWARNINGS": "ignore",
-    "VSI_CACHE": "TRUE",
-    "VSI_CACHE_SIZE": "5000000",
-    "DB_MIN_CONN_SIZE": "1",
-    "DB_MAX_CONN_SIZE": "1"
-  }
+// default settings that can be overridden by the user-provided environment.
+let defaultTitilerPgstacEnv: Record<string, string> = {
+  CPL_VSIL_CURL_ALLOWED_EXTENSIONS: ".tif,.TIF,.tiff",
+  GDAL_CACHEMAX: "200",
+  GDAL_DISABLE_READDIR_ON_OPEN: "EMPTY_DIR",
+  GDAL_INGESTED_BYTES_AT_OPEN: "32768",
+  GDAL_HTTP_MERGE_CONSECUTIVE_RANGES: "YES",
+  GDAL_HTTP_MULTIPLEX: "YES",
+  GDAL_HTTP_VERSION: "2",
+  PYTHONWARNINGS: "ignore",
+  VSI_CACHE: "TRUE",
+  VSI_CACHE_SIZE: "5000000",
+  DB_MIN_CONN_SIZE: "1",
+  DB_MAX_CONN_SIZE: "1",
+};
 
-  export class TitilerPgstacApiLambda extends Construct {
-    readonly url: string;
-    public titilerPgstacLambdaFunction: lambda.Function;
+export class TitilerPgstacApiLambdaRuntime extends Construct {
+  public readonly titilerPgstacLambdaFunction: lambda.Function;
 
-    constructor(scope: Construct, id: string, props: TitilerPgStacApiLambdaProps) {
-      super(scope, id);
+  constructor(
+    scope: Construct,
+    id: string,
+    props: TitilerPgstacApiLambdaRuntimeProps
+  ) {
+    super(scope, id);
 
-      this.titilerPgstacLambdaFunction = new lambda.Function(this, "lambda", {
-        // defaults
-        runtime: lambda.Runtime.PYTHON_3_11,
-        handler: "handler.handler",
-        memorySize: 3008,
-        logRetention: aws_logs.RetentionDays.ONE_WEEK,
-        timeout: Duration.seconds(30),
-        code: lambda.Code.fromDockerBuild(path.join(__dirname, '..'), {
-          file: "titiler-pgstac-api/runtime/Dockerfile",
-          buildArgs: { PYTHON_VERSION: '3.11' }
-        }),
-        vpc: props.vpc,
-        vpcSubnets: props.subnetSelection,
-        allowPublicSubnet: true,
-        // if user provided environment variables, merge them with the defaults.
-        environment: props.apiEnv ? { ...defaultTitilerPgstacEnv, ...props.apiEnv, "PGSTAC_SECRET_ARN": props.dbSecret.secretArn } : defaultTitilerPgstacEnv,
-        // overwrites defaults with user-provided configurable properties
-        ...props.lambdaFunctionOptions,
-      });
+    this.titilerPgstacLambdaFunction = new lambda.Function(this, "lambda", {
+      // defaults
+      runtime: lambda.Runtime.PYTHON_3_11,
+      handler: "handler.handler",
+      memorySize: 3008,
+      logRetention: aws_logs.RetentionDays.ONE_WEEK,
+      timeout: Duration.seconds(30),
+      code: lambda.Code.fromDockerBuild(path.join(__dirname, ".."), {
+        file: "titiler-pgstac-api/runtime/Dockerfile",
+        buildArgs: { PYTHON_VERSION: "3.11" },
+      }),
+      vpc: props.vpc,
+      vpcSubnets: props.subnetSelection,
+      allowPublicSubnet: true,
+      environment: {
+        ...defaultTitilerPgstacEnv,
+        ...props.apiEnv, // if user provided environment variables, merge them with the defaults.
+        PGSTAC_SECRET_ARN: props.dbSecret.secretArn,
+      },
+      // overwrites defaults with user-provided configurable properties
+      ...props.lambdaFunctionOptions,
+    });
 
-      // grant access to buckets using addToRolePolicy
-      if (props.buckets) {
-        props.buckets.forEach(bucket => {
-          this.titilerPgstacLambdaFunction.addToRolePolicy(new iam.PolicyStatement({
+    // grant access to buckets using addToRolePolicy
+    if (props.buckets) {
+      props.buckets.forEach((bucket) => {
+        this.titilerPgstacLambdaFunction.addToRolePolicy(
+          new iam.PolicyStatement({
             actions: ["s3:GetObject"],
             resources: [`arn:aws:s3:::${bucket}/*`],
-          }));
-        });
-      }
-
-      props.dbSecret.grantRead(this.titilerPgstacLambdaFunction);
-
-      if (props.vpc) {
-        this.titilerPgstacLambdaFunction.connections.allowTo(props.db, ec2.Port.tcp(5432), "allow connections from titiler");
-      }
-
-      const stacApi = new apigatewayv2.HttpApi(
-        this,
-        `${Stack.of(this).stackName}-titiler-pgstac-api`,
-        {
-          defaultDomainMapping: props.titilerPgstacApiDomainName
-            ? {
-                domainName: props.titilerPgstacApiDomainName,
-              }
-            : undefined,
-          defaultIntegration:
-            new apigatewayv2_integrations.HttpLambdaIntegration(
-              "integration",
-              this.titilerPgstacLambdaFunction,
-              props.titilerPgstacApiDomainName
-                ? {
-                    parameterMapping:
-                      new apigatewayv2.ParameterMapping().overwriteHeader(
-                        "host",
-                        apigatewayv2.MappingValue.custom(
-                          props.titilerPgstacApiDomainName.name
-                        )
-                      ),
-                  }
-                : undefined
-            ),
-        }
-      );
-
-      this.url = stacApi.url!;
-
-      new CfnOutput(this, "titiler-pgstac-api-output", {
-        exportName: `${Stack.of(this).stackName}-titiler-pgstac-url`,
-        value: this.url,
+          })
+        );
       });
     }
+
+    props.dbSecret.grantRead(this.titilerPgstacLambdaFunction);
+
+    if (props.vpc) {
+      this.titilerPgstacLambdaFunction.connections.allowTo(
+        props.db,
+        ec2.Port.tcp(5432),
+        "allow connections from titiler"
+      );
+    }
   }
+}
 
-  export interface TitilerPgStacApiLambdaProps {
-    /**
-     * VPC into which the lambda should be deployed.
-     */
-    readonly vpc?: ec2.IVpc;
+export interface TitilerPgstacApiLambdaRuntimeProps {
+  /**
+   * VPC into which the lambda should be deployed.
+   */
+  readonly vpc?: ec2.IVpc;
 
-    /**
-     * RDS Instance with installed pgSTAC or pgbouncer server.
-     */
-    readonly db: rds.IDatabaseInstance | ec2.IInstance;
+  /**
+   * RDS Instance with installed pgSTAC or pgbouncer server.
+   */
+  readonly db: rds.IDatabaseInstance | ec2.IInstance;
 
-    /**
-     * Subnet into which the lambda should be deployed.
-     */
-    readonly subnetSelection?: ec2.SubnetSelection;
+  /**
+   * Subnet into which the lambda should be deployed.
+   */
+  readonly subnetSelection?: ec2.SubnetSelection;
 
-    /**
-     * Secret containing connection information for pgSTAC database.
-     */
-    readonly dbSecret: secretsmanager.ISecret;
+  /**
+   * Secret containing connection information for pgSTAC database.
+   */
+  readonly dbSecret: secretsmanager.ISecret;
 
-    /**
-     * Customized environment variables to send to titiler-pgstac runtime. These will be merged with `defaultTitilerPgstacEnv`.
-     * The database secret arn is automatically added to the environment variables at deployment.
-    /*/
-    readonly apiEnv?: Record<string, string>;
+  /**
+   * Customized environment variables to send to titiler-pgstac runtime. These will be merged with `defaultTitilerPgstacEnv`.
+   * The database secret arn is automatically added to the environment variables at deployment.
+   */
+  readonly apiEnv?: Record<string, string>;
 
-    /**
-     * list of buckets the lambda will be granted access to.
-     */
-    readonly buckets?: string[];
+  /**
+   * list of buckets the lambda will be granted access to.
+   */
+  readonly buckets?: string[];
 
-    /**
-     * Custom Domain Name Options for Titiler Pgstac API,
-     *
-     * @default - undefined.
-     */
-    readonly titilerPgstacApiDomainName?: apigatewayv2.IDomainName;
+  /**
+   * Can be used to override the default lambda function properties.
+   *
+   * @default - defined in the construct.
+   */
+  readonly lambdaFunctionOptions?: CustomLambdaFunctionProps;
+}
 
-    /**
-     * Can be used to override the default lambda function properties.
-     *
-     * @default - defined in the construct.
-     */
-    readonly lambdaFunctionOptions?: CustomLambdaFunctionProps;
+export class TitilerPgstacApiLambdaApiGateway extends Construct {
+  readonly url: string;
+
+  constructor(
+    scope: Construct,
+    id: string,
+    props: TitilerPgstacApiLambdaApiGatewayProps
+  ) {
+    super(scope, id);
+
+    const stacApi = new apigatewayv2.HttpApi(
+      this,
+      `${Stack.of(this).stackName}-titiler-pgstac-api`,
+      {
+        defaultDomainMapping: props.titilerPgstacApiDomainName
+          ? {
+              domainName: props.titilerPgstacApiDomainName,
+            }
+          : undefined,
+        defaultIntegration: new apigatewayv2_integrations.HttpLambdaIntegration(
+          "integration",
+          props.lambdaFunction,
+          props.titilerPgstacApiDomainName
+            ? {
+                parameterMapping:
+                  new apigatewayv2.ParameterMapping().overwriteHeader(
+                    "host",
+                    apigatewayv2.MappingValue.custom(
+                      props.titilerPgstacApiDomainName.name
+                    )
+                  ),
+              }
+            : undefined
+        ),
+      }
+    );
+
+    this.url = stacApi.url!;
+
+    new CfnOutput(this, "titiler-pgstac-api-output", {
+      exportName: `${Stack.of(this).stackName}-titiler-pgstac-url`,
+      value: this.url,
+    });
   }
+}
+
+export interface TitilerPgstacApiLambdaApiGatewayProps {
+  /**
+   * Lambda function to integrate with the API Gateway.
+   */
+  readonly lambdaFunction: lambda.Function;
+
+  /**
+   * Custom Domain Name Options for Titiler Pgstac API,
+   *
+   * @default - undefined.
+   */
+  readonly titilerPgstacApiDomainName?: apigatewayv2.IDomainName;
+}
+
+export class TitilerPgstacApiLambda extends Construct {
+  readonly url: string;
+  public titilerPgstacLambdaFunction: lambda.Function;
+
+  constructor(
+    scope: Construct,
+    id: string,
+    props: TitilerPgstacApiLambdaProps
+  ) {
+    super(scope, id);
+
+    const runtime = new TitilerPgstacApiLambdaRuntime(this, "runtime", {
+      vpc: props.vpc,
+      subnetSelection: props.subnetSelection,
+      db: props.db,
+      dbSecret: props.dbSecret,
+      apiEnv: props.apiEnv,
+      buckets: props.buckets,
+      lambdaFunctionOptions: props.lambdaFunctionOptions,
+    });
+    this.titilerPgstacLambdaFunction = runtime.titilerPgstacLambdaFunction;
+
+    const api = new TitilerPgstacApiLambdaApiGateway(this, "api", {
+      lambdaFunction: runtime.titilerPgstacLambdaFunction,
+      titilerPgstacApiDomainName: props.titilerPgstacApiDomainName,
+    });
+
+    this.url = api.url;
+  }
+}
+
+export interface TitilerPgstacApiLambdaProps
+  extends TitilerPgstacApiLambdaRuntimeProps,
+    Omit<TitilerPgstacApiLambdaApiGatewayProps, "lambdaFunction"> {
+  // This interface combines both runtime and API gateway props
+  // The lambdaFunction property from TitilerPgstacApiLambdaApiGatewayProps is excluded
+  // as it will be provided by the runtime construct
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,4 +1,71 @@
-import { aws_lambda as lambda } from "aws-cdk-lib";
+import {
+  aws_lambda as lambda,
+  aws_apigatewayv2 as apigatewayv2,
+  aws_apigatewayv2_integrations as apigatewayv2_integrations,
+  CfnOutput,
+  Stack,
+} from "aws-cdk-lib";
+import { Construct } from "constructs";
 
 export type CustomLambdaFunctionProps = lambda.FunctionProps | any;
 export const DEFAULT_PGSTAC_VERSION = "0.9.5";
+
+export interface LambdaApiGatewayProps {
+  /**
+   * Lambda function to integrate with the API Gateway.
+   */
+  readonly lambdaFunction: lambda.Function;
+
+  /**
+   * Custom Domain Name for the API. If defined, will create the
+   * domain name and integrate it with the API.
+   *
+   * @default - undefined
+   */
+  readonly domainName?: apigatewayv2.IDomainName;
+
+  /**
+   * Name for the CfnOutput export.
+   */
+  readonly outputName: string;
+}
+
+export class LambdaApiGateway extends Construct {
+  readonly url: string;
+
+  constructor(scope: Construct, id: string, props: LambdaApiGatewayProps) {
+    super(scope, id);
+
+    const defaultDomainMapping = props.domainName
+      ? { domainName: props.domainName }
+      : undefined;
+
+    const defaultIntegration =
+      new apigatewayv2_integrations.HttpLambdaIntegration(
+        "integration",
+        props.lambdaFunction,
+        props.domainName
+          ? {
+              parameterMapping:
+                new apigatewayv2.ParameterMapping().overwriteHeader(
+                  "host",
+                  apigatewayv2.MappingValue.custom(props.domainName.name)
+                ),
+            }
+          : undefined
+      );
+
+    const api = new apigatewayv2.HttpApi(this, "api", {
+      apiName: `${Stack.of(this).stackName}-${id}`,
+      defaultDomainMapping,
+      defaultIntegration: defaultIntegration,
+    });
+
+    this.url = api.url!;
+
+    new CfnOutput(this, "output", {
+      exportName: `${Stack.of(this).stackName}-${props.outputName}`,
+      value: this.url,
+    });
+  }
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -28,6 +28,11 @@ export interface LambdaApiGatewayProps {
    * Name for the CfnOutput export.
    */
   readonly outputName: string;
+
+  /**
+   * Name of the API Gateway.
+   */
+  readonly apiName?: string;
 }
 
 export class LambdaApiGateway extends Construct {
@@ -56,7 +61,7 @@ export class LambdaApiGateway extends Construct {
       );
 
     const api = new apigatewayv2.HttpApi(this, "api", {
-      apiName: `${Stack.of(this).stackName}-${id}`,
+      apiName: props.apiName || `${Stack.of(this).stackName}-${id}`,
       defaultDomainMapping,
       defaultIntegration: defaultIntegration,
     });


### PR DESCRIPTION
In this PR, we create separate runtime constructs (ie the Lambda functions) from the API Gateway construct.  We still maintain the higher level constructs that have both the runtime and API Gateway, but it's now possible to import and reuse just the runtime construct which bringing a custom API Gateway (e.g. for situations when a user would want a _private_ API Gateway, which must be a REST API rather than an HTTP API).

> [!WARNING]
> This update will change the internal node IDs of the constructs. This will cause the Lambdas and API Gateways to be redeployed when upgrading eoapi-cdk. Being that both services are stateless, this should not cause issues unless a developer has made manual modifications or manual references to the deployed lambdas/api gateways.

closes #166 
