### PR TITLE
fix(stac-api): avoid base64 encoding application/geo+json data

### DIFF
--- a/lib/stac-api/runtime/Dockerfile
+++ b/lib/stac-api/runtime/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /tmp
 RUN python -m pip install pip -U
 
 COPY stac-api/runtime/requirements.txt requirements.txt
-RUN python -m pip install -r requirements.txt "mangum>=0.14,<0.15" -t /asset --no-binary pydantic
+RUN python -m pip install -r requirements.txt -t /asset --no-binary pydantic
 
 RUN mkdir -p /asset/src
 COPY stac-api/runtime/src/*.py /asset/

--- a/lib/stac-api/runtime/requirements.txt
+++ b/lib/stac-api/runtime/requirements.txt
@@ -1,2 +1,2 @@
-stac-fastapi-pgstac>=5.0,<5.1
+stac-fastapi-pgstac[awslambda]>=5.0,<5.1
 starlette-cramjam>=0.4,<0.5

--- a/lib/stac-api/runtime/src/handler.py
+++ b/lib/stac-api/runtime/src/handler.py
@@ -38,7 +38,15 @@ async def shutdown_event():
     print("DB connection closed.")
 
 
-handler = Mangum(app, lifespan="off")
+handler = Mangum(
+    app, 
+    lifespan="off", 
+    text_mime_types=[
+        # Avoid base64 encoding any text/* or application/* mime-types
+        "text/",
+        "application/"
+    ],
+)
 
 
 if "AWS_EXECUTION_ENV" in os.environ:


### PR DESCRIPTION
When using a REST API with a Lambda Proxy integration (such as when making use of our `PrivateLambdaApiGateway`, [link](https://github.com/developmentseed/eoapi-cdk/blob/738f13a2307aaa9e230b7ee07f524afceb4d84c2/lib/lambda-api-gateway-private/index.ts#L103-L133)), data that Mangum converts to base64 is _not_ converted to text by the API Gateway.

By default, Mangum v0.14.1 converts any text data to base64 aside from its builtin defaults[^1]. These defaults do not include `application/geo+json` which is used by the STAC API. This PR upgrades Mangum (by utilizing `stac-fastapi-pgstac`'s unspecified `mangum` version[^2]) and configures Mangum to avoid converting any data to base64 that begins with `text/` or `application/`.

**Question:** Perhaps we should just disable the base64 conversion completely by specifying a text mime type of `''` which would match all `mime_type in content_type`[^3] lookups?

[^1]: https://github.com/Kludex/mangum/blob/0.14.1/docs/http.md#text-mime-types
[^2]: https://github.com/stac-utils/stac-fastapi-pgstac/blob/d43ea548103d0e157d7e22fb70f9ea9fe310509b/setup.py#L49C6-L49C15
[^3]: https://github.com/Kludex/mangum/blob/0.14.1/mangum/handlers/utils.py#L79