### PR TITLE
fix(titiler): ceil pyproj dependency

### DIFF
--- a/lib/tipg-api/runtime/requirements.txt
+++ b/lib/tipg-api/runtime/requirements.txt
@@ -1,1 +1,3 @@
 tipg>=1.0,<1.1
+# pyproj 3.7.2 didn't include wheels for our Docker image
+pyproj<3.7.2

--- a/lib/titiler-pgstac-api/runtime/requirements.txt
+++ b/lib/titiler-pgstac-api/runtime/requirements.txt
@@ -2,3 +2,5 @@ titiler.pgstac>=1.7,<1.8
 numpy>=2.2.6,<2.3.0
 numexpr>=2.10.0,<2.10.1
 psycopg[binary, pool]
+# pyproj 3.7.2 didn't include wheels for our Docker image
+pyproj<3.7.2


### PR DESCRIPTION
## :warning: Checklist if your PR is changing anything else than documentation
- [ ] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction): https://github.com/developmentseed/eoapi-cdk/actions/runs/16977222541

## Merge request description

[pyproj v3.7.2](https://pypi.org/project/pyproj/3.7.2/) was released today, and they updated their manylinux wheels to [manylinux_2_28](https://files.pythonhosted.org/packages/c0/7d/a9f41e814dc4d1dc54e95b2ccaf0b3ebe3eb18b1740df05fe334724c3d89/pyproj-3.7.2-cp311-cp311-manylinux_2_28_aarch64.whl). That's too new for our `public.ecr.aws/lambda/python:3.11` image, so Docker was trying to build the wheels and failing b/c there was no **proj** on the system (nor should there be). This PR puts a ceiling on the titiler transative **pyproj** requirement until https://github.com/developmentseed/eoapi-cdk/issues/157 is resolved. 

**Update**: other builds, including (at least) **tipg** are affected as well.