### PR TITLE
fix: include libexpat.so.1 in the titiler code package

### DIFF
--- a/lib/titiler-pgstac-api/runtime/Dockerfile
+++ b/lib/titiler-pgstac-api/runtime/Dockerfile
@@ -10,6 +10,10 @@ RUN dnf install -y gcc-c++ findutils
 COPY titiler-pgstac-api/runtime/requirements.txt requirements.txt
 RUN python -m pip install -r requirements.txt "mangum>=0.14,<0.15" -t /asset
 
+# copy libexpat.so.1 into a location included in LD_LIBRARY_PATH in the Lambda runtime environment
+# (/usr/lib64 is not available in the Lambda runtime, just the build environment)
+RUN cp /usr/lib64/libexpat.so.1 /asset/
+
 # Remove system dependencies
 RUN dnf remove -y gcc-c++
 


### PR DESCRIPTION
## :warning: Checklist if your PR is changing anything else than documentation
- [x] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction) https://github.com/developmentseed/eoapi-cdk/actions/runs/17114410152

## Merge request description
This was one of the main gotchas for the Python 3.12 runtime upgrade but I forgot about it :disappointed: 

From https://github.com/developmentseed/titiler/discussions/1108:

> I think it is a brittle solution but it might work for you too. The problem is that the execution environment is subtly different from the build environment as @vincentsarago suggested earlier. In this case the build environment (Lambda Python 3.12 image) has libexpat.so.1 available in the LD_LIBRARY_PATH which includes /usr/lib64 but the execution environment does not. The contents of the /asset directory which get zipped up to create the code package for the Lambda gets added to LD_LIBRARY_PATH so I think that's why it works. I hope that helps!

resolves #181 