### PR TITLE
fix: add token permissions for OIDC publishing

### DIFF
--- a/.github/workflows/distribute.yaml
+++ b/.github/workflows/distribute.yaml
@@ -13,28 +13,33 @@ jobs:
   distribute-python:
     runs-on: ubuntu-latest
     needs: package
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: python
           path: dist
 
-      - run: pip install "twine>=6.1.0" "packaging>=24.2"
-
-      - run: twine upload dist/*
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
 
   distribute-js:
     runs-on: ubuntu-latest
     needs: package
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: js
           path: dist
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           registry-url: "https://registry.npmjs.org"
 
-      - run: npm publish dist/*
+      - run: npm publish dist/ --provenance --access public


### PR DESCRIPTION
## Merge request description

Both pypi and npm publishing actions are broken right now!
