### PR TITLE
ci: skip ci actions that require tokens for dependabot PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,14 +59,14 @@ jobs:
 
       - name: Get Release Bot Token
         id: get-token
-        if: ${{ inputs.release }}
+        if: ${{ inputs.release && github.actor != 'dependabot[bot]' }}
         uses: getsentry/action-github-app-token@v1
         with:
           app_id: ${{ secrets.DS_RELEASE_BOT_ID }}
           private_key: ${{ secrets.DS_RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Maybe Release 🚀
-        if: "${{ inputs.release }}"
+        if: ${{ inputs.release && github.actor != 'dependabot[bot]' }}
         run: |
           npm run semantic-release
         env:

--- a/.github/workflows/conventional-pr.yaml
+++ b/.github/workflows/conventional-pr.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   lint-pr:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
When dependabot opens PRs, don't do the things that require GitHub tokens.