### PR TITLE
feat: add option to enable SnapStart for Lambda functions

### DIFF
--- a/lib/lambda-api-gateway/index.ts
+++ b/lib/lambda-api-gateway/index.ts
@@ -10,7 +10,7 @@ export interface LambdaApiGatewayProps {
   /**
    * Lambda function to integrate with the API Gateway.
    */
-  readonly lambdaFunction: lambda.Function;
+  readonly lambdaFunction: lambda.Function | lambda.Version;
 
   /**
    * Custom Domain Name for the API. If defined, will create the

--- a/lib/stac-api/index.ts
+++ b/lib/stac-api/index.ts
@@ -69,7 +69,8 @@ export class PgStacApiLambdaRuntime extends Construct {
 
     const enabledExtensions = props.enabledExtensions || defaultExtensions;
 
-    const { code: userCode, ...otherLambdaOptions } = props.lambdaFunctionOptions || {};
+    const { code: userCode, ...otherLambdaOptions } =
+      props.lambdaFunctionOptions || {};
 
     this.lambdaFunction = new lambda.Function(this, "lambda", {
       // defaults
@@ -78,14 +79,10 @@ export class PgStacApiLambdaRuntime extends Construct {
       memorySize: 8192,
       logRetention: aws_logs.RetentionDays.ONE_WEEK,
       timeout: Duration.seconds(30),
-      code: resolveLambdaCode(
-        userCode,
-        path.join(__dirname, ".."),
-        {
-          file: "stac-api/runtime/Dockerfile",
-          buildArgs: { PYTHON_VERSION: "3.12" },
-        }
-      ),
+      code: resolveLambdaCode(userCode, path.join(__dirname, ".."), {
+        file: "stac-api/runtime/Dockerfile",
+        buildArgs: { PYTHON_VERSION: "3.12" },
+      }),
       vpc: props.vpc,
       vpcSubnets: props.subnetSelection,
       allowPublicSubnet: true,
@@ -96,6 +93,9 @@ export class PgStacApiLambdaRuntime extends Construct {
         ENABLED_EXTENSIONS: enabledExtensions.join(","),
         ...props.apiEnv,
       },
+      snapStart: props.enableSnapStart
+        ? lambda.SnapStartConf.ON_PUBLISHED_VERSIONS
+        : undefined,
       // overwrites defaults with user-provided configurable properties (excluding code)
       ...otherLambdaOptions,
     });
@@ -146,6 +146,13 @@ export interface PgStacApiLambdaRuntimeProps {
   readonly enabledExtensions?: ExtensionType[];
 
   /**
+   * Enable SnapStart.
+   *
+   * @default - false
+   */
+  readonly enableSnapStart?: boolean;
+
+  /**
    * Can be used to override the default lambda function properties.
    *
    * @default - defined in the construct.
@@ -179,12 +186,15 @@ export class PgStacApiLambda extends Construct {
       dbSecret: props.dbSecret,
       enabledExtensions: props.enabledExtensions,
       apiEnv: props.apiEnv,
+      enableSnapStart: props.enableSnapStart,
       lambdaFunctionOptions: props.lambdaFunctionOptions,
     });
     this.stacApiLambdaFunction = this.lambdaFunction = runtime.lambdaFunction;
 
     const { api } = new LambdaApiGateway(this, "stac-api", {
-      lambdaFunction: runtime.lambdaFunction,
+      lambdaFunction: props.enableSnapStart!
+        ? runtime.lambdaFunction.currentVersion
+        : runtime.lambdaFunction,
       domainName: props.domainName ?? props.stacApiDomainName,
     });
 

--- a/lib/stac-api/runtime/src/handler.py
+++ b/lib/stac-api/runtime/src/handler.py
@@ -6,7 +6,8 @@ import asyncio
 import os
 
 from mangum import Mangum
-from stac_fastapi.pgstac.app import app
+from snapshot_restore_py import register_after_restore, register_before_snapshot
+from stac_fastapi.pgstac.app import app, with_transactions
 from stac_fastapi.pgstac.config import PostgresSettings
 from stac_fastapi.pgstac.db import close_db_connection, connect_to_db
 from utils import get_secret_dict
@@ -21,12 +22,92 @@ postgres_settings = PostgresSettings(
     postgres_port=int(secret["port"]),
 )
 
+_connection_initialized = False
+
+
+@register_before_snapshot
+def on_snapshot():
+    """
+    Runtime hook called by Lambda before taking a snapshot.
+    We close database connections that shouldn't be in the snapshot.
+    """
+
+    # Close any existing database connections before the snapshot is taken
+    if hasattr(app, "state") and hasattr(app.state, "readpool") and app.state.readpool:
+        try:
+            app.state.readpool.close()
+            app.state.readpool = None
+        except Exception as e:
+            print(f"SnapStart: Error closing database readpool: {e}")
+
+    if hasattr(app, "state") and hasattr(app.state, "writepool") and app.state.writepool:
+        try:
+            app.state.writepool.close()
+            app.state.writepool = None
+        except Exception as e:
+            print(f"SnapStart: Error closing database writepool: {e}")
+
+    return {"statusCode": 200}
+
+
+@register_after_restore
+def on_snap_restore():
+    """
+    Runtime hook called by Lambda after restoring from a snapshot.
+    We recreate database connections that were closed before the snapshot.
+    """
+    global _connection_initialized
+
+    try:
+        # Get the event loop or create a new one
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        # Close any existing pool (from snapshot)
+        if hasattr(app.state, "readpool") and app.state.readpool:
+            try:
+                app.state.readpool.close()
+            except Exception as e:
+                print(f"SnapStart: Error closing stale readpool: {e}")
+            app.state.readpool = None
+
+        if hasattr(app.state, "writepool") and app.state.writepool:
+            try:
+                app.state.writepool.close()
+            except Exception as e:
+                print(f"SnapStart: Error closing stale writepool: {e}")
+            app.state.writepool = None
+
+        # Create fresh connection pool
+        loop.run_until_complete(
+            connect_to_db(
+                app,
+                postgres_settings=postgres_settings,
+                add_write_connection_pool=with_transactions,
+            )
+        )
+
+        _connection_initialized = True
+
+    except Exception as e:
+        print(f"SnapStart: Failed to initialize database connection: {e}")
+        raise
+
+    return {"statusCode": 200}
+
 
 @app.on_event("startup")
 async def startup_event():
     """Connect to database on startup."""
     print("Setting up DB connection...")
-    await connect_to_db(app, postgres_settings=postgres_settings)
+    await connect_to_db(
+        app,
+        postgres_settings=postgres_settings,
+        add_write_connection_pool=with_transactions,
+    )
     print("DB connection setup.")
 
 

--- a/lib/tipg-api/index.ts
+++ b/lib/tipg-api/index.ts
@@ -20,7 +20,8 @@ export class TiPgApiLambdaRuntime extends Construct {
   constructor(scope: Construct, id: string, props: TiPgApiLambdaRuntimeProps) {
     super(scope, id);
 
-    const { code: userCode, ...otherLambdaOptions } = props.lambdaFunctionOptions || {};
+    const { code: userCode, ...otherLambdaOptions } =
+      props.lambdaFunctionOptions || {};
 
     this.lambdaFunction = new lambda.Function(this, "lambda", {
       // defaults
@@ -29,14 +30,10 @@ export class TiPgApiLambdaRuntime extends Construct {
       memorySize: 1024,
       logRetention: logs.RetentionDays.ONE_WEEK,
       timeout: Duration.seconds(30),
-      code: resolveLambdaCode(
-        userCode,
-        path.join(__dirname, ".."),
-        {
-          file: "tipg-api/runtime/Dockerfile",
-          buildArgs: { PYTHON_VERSION: "3.12" },
-        }
-      ),
+      code: resolveLambdaCode(userCode, path.join(__dirname, ".."), {
+        file: "tipg-api/runtime/Dockerfile",
+        buildArgs: { PYTHON_VERSION: "3.12" },
+      }),
       vpc: props.vpc,
       vpcSubnets: props.subnetSelection,
       allowPublicSubnet: true,
@@ -46,6 +43,9 @@ export class TiPgApiLambdaRuntime extends Construct {
         DB_MAX_CONN_SIZE: "1",
         ...props.apiEnv,
       },
+      snapStart: props.enableSnapStart
+        ? lambda.SnapStartConf.ON_PUBLISHED_VERSIONS
+        : undefined,
       // overwrites defaults with user-provided configurable properties (excluding code)
       ...otherLambdaOptions,
     });
@@ -89,6 +89,13 @@ export interface TiPgApiLambdaRuntimeProps {
   readonly apiEnv?: Record<string, string>;
 
   /**
+   * Enable SnapStart.
+   *
+   * @default - false
+   */
+  readonly enableSnapStart?: boolean;
+
+  /**
    * Can be used to override the default lambda function properties.
    *
    * @default - defined in the construct.
@@ -121,12 +128,15 @@ export class TiPgApiLambda extends Construct {
       db: props.db,
       dbSecret: props.dbSecret,
       apiEnv: props.apiEnv,
+      enableSnapStart: props.enableSnapStart,
       lambdaFunctionOptions: props.lambdaFunctionOptions,
     });
     this.tiPgLambdaFunction = this.lambdaFunction = runtime.lambdaFunction;
 
     const { api } = new LambdaApiGateway(this, "api", {
-      lambdaFunction: runtime.lambdaFunction,
+      lambdaFunction: props.enableSnapStart!
+        ? runtime.lambdaFunction.currentVersion
+        : runtime.lambdaFunction,
       domainName: props.domainName ?? props.tipgApiDomainName,
     });
 

--- a/lib/tipg-api/runtime/src/handler.py
+++ b/lib/tipg-api/runtime/src/handler.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 
 from mangum import Mangum
+from snapshot_restore_py import register_after_restore, register_before_snapshot
 from tipg.collections import register_collection_catalog
 from tipg.database import connect_to_db
 from tipg.main import app
@@ -26,6 +27,77 @@ postgres_settings = PostgresSettings(
 )
 db_settings = DatabaseSettings()
 custom_sql_settings = CustomSQLSettings()
+
+_connection_initialized = False
+
+
+@register_before_snapshot
+def on_snapshot():
+    """
+    Runtime hook called by Lambda before taking a snapshot.
+    We close database connections that shouldn't be in the snapshot.
+    """
+
+    # Close any existing database connections before the snapshot is taken
+    if hasattr(app, "state") and hasattr(app.state, "pool") and app.state.pool:
+        try:
+            app.state.pool.close()
+            app.state.pool = None
+        except Exception as e:
+            print(f"SnapStart: Error closing database pool: {e}")
+
+    return {"statusCode": 200}
+
+
+@register_after_restore
+def on_snap_restore():
+    """
+    Runtime hook called by Lambda after restoring from a snapshot.
+    We recreate database connections that were closed before the snapshot.
+    """
+    global _connection_initialized
+
+    try:
+        # Get the event loop or create a new one
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        # Close any existing pool (from snapshot)
+        if hasattr(app.state, "pool") and app.state.pool:
+            try:
+                app.state.pool.close()
+            except Exception as e:
+                print(f"SnapStart: Error closing stale pool: {e}")
+            app.state.pool = None
+
+        # Create fresh connection pool
+        loop.run_until_complete(
+            connect_to_db(
+                app,
+                schemas=db_settings.schemas,
+                tipg_schema=db_settings.tipg_schema,
+                user_sql_files=custom_sql_settings.sql_files,
+                settings=postgres_settings,
+            )
+        )
+
+        loop.run_until_complete(
+            register_collection_catalog(
+                app,
+                db_settings=db_settings,
+            )
+        )
+
+        _connection_initialized = True
+
+    except Exception as e:
+        print(f"SnapStart: Failed to initialize database connection: {e}")
+        raise
+
+    return {"statusCode": 200}
 
 
 @app.on_event("startup")

--- a/lib/titiler-pgstac-api/runtime/src/handler.py
+++ b/lib/titiler-pgstac-api/runtime/src/handler.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 
 from mangum import Mangum
+from snapshot_restore_py import register_after_restore, register_before_snapshot
 from titiler.pgstac.db import connect_to_db
 from titiler.pgstac.main import app
 from titiler.pgstac.settings import PostgresSettings
@@ -19,6 +20,62 @@ postgres_settings = PostgresSettings(
     postgres_pass=secret["password"],
     postgres_port=int(secret["port"]),
 )
+
+_connection_initialized = False
+
+
+@register_before_snapshot
+def on_snapshot():
+    """
+    Runtime hook called by Lambda before taking a snapshot.
+    We close database connections that shouldn't be in the snapshot.
+    """
+
+    # Close any existing database connections before the snapshot is taken
+    if hasattr(app, "state") and hasattr(app.state, "dbpool") and app.state.dbpool:
+        try:
+            app.state.dbpool.close()
+            app.state.dbpool = None
+        except Exception as e:
+            print(f"SnapStart: Error closing database pool: {e}")
+
+    return {"statusCode": 200}
+
+
+@register_after_restore
+def on_snap_restore():
+    """
+    Runtime hook called by Lambda after restoring from a snapshot.
+    We recreate database connections that were closed before the snapshot.
+    """
+    global _connection_initialized
+
+    try:
+        # Get the event loop or create a new one
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        # Close any existing pool (from snapshot)
+        if hasattr(app.state, "dbpool") and app.state.dbpool:
+            try:
+                app.state.dbpool.close()
+            except Exception as e:
+                print(f"SnapStart: Error closing stale pool: {e}")
+            app.state.dbpool = None
+
+        # Create fresh connection pool
+        loop.run_until_complete(connect_to_db(app, settings=postgres_settings))
+
+        _connection_initialized = True
+
+    except Exception as e:
+        print(f"SnapStart: Failed to initialize database connection: {e}")
+        raise
+
+    return {"statusCode": 200}
 
 
 @app.on_event("startup")


### PR DESCRIPTION
## :warning: Checklist if your PR is changing anything else than documentation
- [ ] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction)

## Merge request description
SnapStart reduces the cold start time for titiler-pgstac from ~6.5 seconds to ~1.5 seconds! This PR adds a boolean `enableSnapStart` flag to the stac-api, titiler-pgstac-api, and tipg-api contsructs.