### PR TITLE
fix: pin to affine<3 in stactools item generator

### DIFF
--- a/lib/stactools-item-generator/runtime/src/stactools_item_generator/item.py
+++ b/lib/stactools-item-generator/runtime/src/stactools_item_generator/item.py
@@ -49,7 +49,7 @@ def create_stac_item(request: ItemRequest) -> Item:
     command = [
         "uvx",
         "--with",
-        f"requests,numpy<2.3.0,{request.package_name}",
+        f"requests,numpy<2.3.0,affine<3,{request.package_name}",
         "--from",
         "stactools",
         "stac",

--- a/lib/stactools-item-generator/runtime/tests/test_item.py
+++ b/lib/stactools-item-generator/runtime/tests/test_item.py
@@ -70,6 +70,6 @@ def test_item(item_request: ItemRequest, mock_stactools_command: list[list[str]]
     stac_item = create_stac_item(item_request)
     command = mock_stactools_command[0]
     assert command[0] == "uvx"
-    assert command[2].endswith(item_request.package_name)
+    assert command[2] == (f"requests,numpy<2.3.0,affine<3,{item_request.package_name}")
     if item_request.collection_id:
         assert stac_item.collection == item_request.collection_id


### PR DESCRIPTION
## Merge request description
affine v3.0 made the Affine object not JSON-serializable which is a problem for various downstream applications.